### PR TITLE
テーマカラー設定の実装 (#40)

### DIFF
--- a/app/src/androidTest/java/io/kokoichi/sample/sakamichiapp/presentation/setting/CacheClearDialogTest.kt
+++ b/app/src/androidTest/java/io/kokoichi/sample/sakamichiapp/presentation/setting/CacheClearDialogTest.kt
@@ -16,6 +16,7 @@ import io.kokoichi.sample.sakamichiapp.presentation.MainActivity
 import io.kokoichi.sample.sakamichiapp.presentation.util.TestTags
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Rule
@@ -35,6 +36,9 @@ class CacheClearDialogTest {
     @RelaxedMockK
     lateinit var navController: NavController
 
+    @RelaxedMockK
+    lateinit var uiState: SettingsUiState
+
     @Before
     fun setUp() {
         hiltRule.inject()
@@ -43,6 +47,7 @@ class CacheClearDialogTest {
         composeRule.setContent {
             CacheClearDialog(
                 navController = navController,
+                uiState = uiState,
             )
         }
     }

--- a/app/src/androidTest/java/io/kokoichi/sample/sakamichiapp/presentation/setting/ReportIssueScreenTest.kt
+++ b/app/src/androidTest/java/io/kokoichi/sample/sakamichiapp/presentation/setting/ReportIssueScreenTest.kt
@@ -35,6 +35,9 @@ class ReportIssueScreenTest {
     @RelaxedMockK
     lateinit var viewModel: SettingsViewModel
 
+    @RelaxedMockK
+    lateinit var uiState: SettingsUiState
+
     @Before
     fun setUp() {
         hiltRule.inject()
@@ -43,6 +46,7 @@ class ReportIssueScreenTest {
         composeRule.setContent {
             ReportIssueScreen(
                 viewModel = viewModel,
+                uiState = uiState,
             )
         }
     }

--- a/app/src/androidTest/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SetThemeScreenTest.kt
+++ b/app/src/androidTest/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SetThemeScreenTest.kt
@@ -1,0 +1,145 @@
+package io.kokoichi.sample.sakamichiapp.presentation.setting
+
+import android.content.Context
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.navigation.NavHostController
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import io.kokoichi.sample.sakamichiapp.R
+import io.kokoichi.sample.sakamichiapp.di.AppModule
+import io.kokoichi.sample.sakamichiapp.presentation.MainActivity
+import io.kokoichi.sample.sakamichiapp.presentation.util.TestTags
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalMaterialApi
+@HiltAndroidTest
+@UninstallModules(AppModule::class)
+class SetThemeScreenTest {
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @RelaxedMockK
+    lateinit var navController: NavHostController
+
+    @RelaxedMockK
+    lateinit var viewModel: SettingsViewModel
+
+    lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+        MockKAnnotations.init(this)
+
+        composeRule.setContent {
+            context = LocalContext.current
+            SetThemeScreen(
+                navController = navController,
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    @Test
+    fun setThemeScreen_display() {
+        // Arrange
+        val expectedStr =
+            context.resources.getString(R.string.set_theme_title)
+
+        // Act
+
+        // Assert
+        composeRule
+            .onNodeWithTag(TestTags.SET_THEME_TITLE)
+            .assertExists()
+            .assertTextEquals(expectedStr)
+        composeRule
+            .onNodeWithTag(TestTags.SET_THEME_BACK_ARROW)
+            .assertExists()
+        // Only one Check Icon
+        composeRule
+            .onNodeWithContentDescription("check")
+            .assertExists()
+        // At least one theme row
+        composeRule
+            .onAllNodesWithTag(TestTags.SET_THEME_THEME)[0]
+            .assertExists()
+    }
+
+    @Test
+    fun onBackArrowClicked_navigatePopBackStack() {
+        // Arrange
+        verify(exactly = 0) {
+            navController.popBackStack()
+        }
+
+        // Act
+        composeRule
+            .onNodeWithTag(TestTags.SET_THEME_BACK_ARROW)
+            .performClick()
+
+        // Assert
+        verify(exactly = 1) {
+            navController.popBackStack()
+        }
+    }
+
+    @Test
+    fun onOtherThanBackArrowClicked_notNavigate() {
+        // Arrange
+        verify(exactly = 0) {
+            navController.navigateUp()
+            navController.popBackStack()
+        }
+
+        // Act
+        composeRule
+            .onNodeWithTag(TestTags.SET_THEME_TITLE)
+            .performClick()
+        composeRule
+            .onAllNodesWithTag(TestTags.SET_THEME_THEME)[0]
+            .performClick()
+        composeRule
+            .onNodeWithContentDescription("check")
+            .assertExists()
+
+        // Assert
+        verify(exactly = 0) {
+            navController.navigateUp()
+            navController.popBackStack()
+        }
+    }
+
+    @Test
+    fun onThemeClicked_setTheme() {
+        // Arrange
+        val theme = ThemeType.Sakurazaka
+        verify(exactly = 0) {
+            viewModel.setThemeType(theme)
+            viewModel.writeTheme(context, theme.name)
+        }
+
+        // Act
+        composeRule
+            .onNodeWithText(theme.name)
+            .performClick()
+
+        // Assert
+        verify(exactly = 1) {
+            viewModel.setThemeType(theme)
+            viewModel.writeTheme(context, theme.name)
+        }
+    }
+}

--- a/app/src/androidTest/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingTopScreenTest.kt
+++ b/app/src/androidTest/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingTopScreenTest.kt
@@ -34,6 +34,9 @@ class SettingTopScreenTest {
     @RelaxedMockK
     lateinit var navController: NavController
 
+    @RelaxedMockK
+    lateinit var uiState: SettingsUiState
+
     @Before
     fun setUp() {
         hiltRule.inject()
@@ -47,6 +50,7 @@ class SettingTopScreenTest {
                 navController = navController,
                 navigationList = navigation,
                 viewModel = mockk(),
+                uiState = uiState,
             )
         }
     }

--- a/app/src/androidTest/java/io/kokoichi/sample/sakamichiapp/presentation/setting/UpdateBlogScreenTest.kt
+++ b/app/src/androidTest/java/io/kokoichi/sample/sakamichiapp/presentation/setting/UpdateBlogScreenTest.kt
@@ -1,7 +1,6 @@
 package io.kokoichi.sample.sakamichiapp.presentation.setting
 
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -34,6 +33,12 @@ class UpdateBlogScreenTest {
     @RelaxedMockK
     lateinit var navController: NavHostController
 
+    @RelaxedMockK
+    lateinit var viewModel: SettingsViewModel
+
+    @RelaxedMockK
+    lateinit var uiState: SettingsUiState
+
     @Before
     fun setUp() {
         hiltRule.inject()
@@ -42,7 +47,8 @@ class UpdateBlogScreenTest {
         composeRule.setContent {
             UpdateBlogScreen(
                 navController = navController,
-                viewModel = mockk()
+                viewModel = viewModel,
+                uiState = uiState,
             )
         }
     }

--- a/app/src/androidTest/java/io/kokoichi/sample/sakamichiapp/presentation/util/BottomNavigationBarTest.kt
+++ b/app/src/androidTest/java/io/kokoichi/sample/sakamichiapp/presentation/util/BottomNavigationBarTest.kt
@@ -52,7 +52,8 @@ class BottomNavigationBarTest {
                     BottomNavItem.Position,
                     BottomNavItem.Quiz,
                     BottomNavItem.Setting,
-                )
+                ),
+                themeType = "",
             )
         }
     }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/CacheClearDialog.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/CacheClearDialog.kt
@@ -21,13 +21,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import io.kokoichi.sample.sakamichiapp.R
-import io.kokoichi.sample.sakamichiapp.presentation.ui.theme.SubColorS
 import io.kokoichi.sample.sakamichiapp.presentation.util.TestTags
 import java.io.File
 
 @Composable
 fun CacheClearDialog(
     navController: NavController,
+    uiState: SettingsUiState,
 ) {
     Surface(
         modifier = Modifier
@@ -66,7 +66,7 @@ fun CacheClearDialog(
                             modifier = Modifier
                                 .weight(1f)
                                 .clip(RoundedCornerShape(5.dp))
-                                .background(SubColorS)
+                                .background(uiState.themeType.subColor)
                                 .testTag(TestTags.CACHE_CLEAR_DIALOG_OK),
                             onClick = {
                                 openDialog.value = false
@@ -88,7 +88,7 @@ fun CacheClearDialog(
                                 .weight(1f)
                                 .border(
                                     width = 1.dp,
-                                    color = SubColorS,
+                                    color = uiState.themeType.subColor,
                                     shape = RoundedCornerShape(5.dp)
                                 )
                                 .testTag(TestTags.CACHE_CLEAR_DIALOG_CANCEL),
@@ -99,7 +99,7 @@ fun CacheClearDialog(
                         ) {
                             Text(
                                 text = stringResource(R.string.clear_cache_cancel),
-                                color = SubColorS,
+                                color = uiState.themeType.subColor,
                             )
                         }
                     }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/ReportIssueScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/ReportIssueScreen.kt
@@ -19,13 +19,13 @@ import androidx.compose.ui.unit.dp
 import io.kokoichi.sample.sakamichiapp.R
 import io.kokoichi.sample.sakamichiapp.presentation.ui.theme.SpaceMedium
 import io.kokoichi.sample.sakamichiapp.presentation.ui.theme.SpaceSmall
-import io.kokoichi.sample.sakamichiapp.presentation.ui.theme.SubColorS
 import io.kokoichi.sample.sakamichiapp.presentation.util.Constants
 import io.kokoichi.sample.sakamichiapp.presentation.util.TestTags
 
 @Composable
 fun ReportIssueScreen(
-    viewModel: SettingsViewModel
+    viewModel: SettingsViewModel,
+    uiState: SettingsUiState,
 ) {
     var isDialogOpen by remember { mutableStateOf(false) }
 
@@ -58,7 +58,7 @@ fun ReportIssueScreen(
                 .background(Color.White)
                 .border(
                     width = 2.dp,
-                    color = Color.LightGray,
+                    color = uiState.themeType.subColor,
                     shape = boxShape
                 )
                 .testTag(TestTags.REPORT_ISSUE_BODY),
@@ -86,7 +86,7 @@ fun ReportIssueScreen(
                 }
                 .testTag(TestTags.REPORT_ISSUE_BUTTON),
             text = stringResource(R.string.report_issue_submit_button),
-            color = SubColorS,
+            color = uiState.themeType.baseColor,
             style = MaterialTheme.typography.h6,
         )
     }
@@ -124,7 +124,7 @@ fun ReportIssueScreen(
                         modifier = Modifier
                             .weight(1f)
                             .clip(RoundedCornerShape(5.dp))
-                            .background(SubColorS)
+                            .background(uiState.themeType.subColor)
                             .testTag(TestTags.REPORT_ISSUE_DIALOG_OK),
                         onClick = {
                             isDialogOpen = false
@@ -135,7 +135,7 @@ fun ReportIssueScreen(
                         Text(
                             modifier = Modifier,
                             text = stringResource(R.string.report_issue_dialog_button_ok),
-                            color = Color.White,
+                            color = uiState.themeType.fontColor,
                         )
                     }
                     // Some space same as the start, end and bottom
@@ -145,7 +145,7 @@ fun ReportIssueScreen(
                             .weight(1f)
                             .border(
                                 width = 1.dp,
-                                color = SubColorS,
+                                color = uiState.themeType.subColor,
                                 shape = RoundedCornerShape(5.dp)
                             )
                             .testTag(TestTags.REPORT_ISSUE_DIALOG_CANCEL),
@@ -155,7 +155,7 @@ fun ReportIssueScreen(
                     ) {
                         Text(
                             text = stringResource(R.string.report_issue_dialog_button_cancel),
-                            color = SubColorS,
+                            color = uiState.themeType.subColor,
                         )
                     }
                 }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SetThemeScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SetThemeScreen.kt
@@ -31,11 +31,11 @@ import io.kokoichi.sample.sakamichiapp.presentation.util.TestTags
 fun SetThemeScreen(
     navController: NavHostController,
     viewModel: SettingsViewModel,
+    selected: String = ThemeType.BasicNight.name,
 ) {
-    var selectedItem by remember { mutableStateOf(viewModel.uiState.value.themeType.name)}
+    var selectedItem by remember { mutableStateOf(selected) }
 
     val context = LocalContext.current
-
 
     Column {
         ThemeTopBar(

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SetThemeScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SetThemeScreen.kt
@@ -1,0 +1,4 @@
+package io.kokoichi.sample.sakamichiapp.presentation.setting
+
+class SetThemeScreen(viewModel: SettingsViewModel) {
+}

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SetThemeScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SetThemeScreen.kt
@@ -1,4 +1,167 @@
 package io.kokoichi.sample.sakamichiapp.presentation.setting
 
-class SetThemeScreen(viewModel: SettingsViewModel) {
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import io.kokoichi.sample.sakamichiapp.R
+import io.kokoichi.sample.sakamichiapp.presentation.ui.theme.*
+import io.kokoichi.sample.sakamichiapp.presentation.util.TestTags
+
+@Composable
+fun SetThemeScreen(
+    navController: NavHostController,
+    viewModel: SettingsViewModel,
+) {
+    var selectedItem by remember { mutableStateOf(viewModel.uiState.value.themeType.name)}
+
+    val context = LocalContext.current
+
+
+    Column {
+        ThemeTopBar(
+            themeType = themeTypes.first { it.name == selectedItem },
+            onArrowClick = {
+                navController.popBackStack()
+            },
+        )
+        Spacer(modifier = Modifier.height(SpaceMedium))
+        ThemeTypesColumn(
+            selectedItem = selectedItem,
+            colorTypes = themeTypes,
+            onclick = { type ->
+                selectedItem = type.name
+                viewModel.setThemeType(type)
+                viewModel.writeTheme(context, type.name)
+            }
+        )
+    }
+}
+
+@Composable
+fun ThemeTopBar(
+    themeType: ThemeType,
+    onArrowClick: () -> Unit = {},
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(themeType.subColor)
+            .padding(SpaceMedium),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(TestTags.SET_THEME_TITLE),
+            text = stringResource(R.string.set_theme_title),
+            style = Typography.h5,
+            color = themeType.fontColor,
+            textAlign = TextAlign.Center,
+        )
+        Icon(
+            imageVector = Icons.Default.ArrowBack,
+            contentDescription = "back",
+            tint = themeType.fontColor,
+            modifier = Modifier
+                .size(30.dp)
+                .clickable {
+                    onArrowClick()
+                }
+                .testTag(TestTags.SET_THEME_BACK_ARROW),
+        )
+    }
+}
+
+@Composable
+fun ThemeTypesColumn(
+    selectedItem: String,
+    colorTypes: List<ThemeType>,
+    onclick: (ThemeType) -> Unit = {},
+) {
+    LazyColumn {
+        items(colorTypes) { type ->
+            ColorRow(
+                type = type,
+                isSelected = type.name == selectedItem,
+                onclick = {
+                    onclick(type)
+                },
+            )
+            Divider(
+                color = Color.LightGray,
+                thickness = 1.dp,
+            )
+        }
+    }
+}
+
+@Composable
+fun ColorRow(
+    type: ThemeType,
+    isSelected: Boolean = false,
+    onclick: (ThemeType) -> Unit = {},
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable {
+                onclick(type)
+            }
+            .padding(SpaceMedium)
+            .testTag(TestTags.SET_THEME_THEME),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Spacer(modifier = Modifier.width(SpaceSmall))
+        Box(
+            modifier = Modifier
+                .size(25.dp)
+                .clip(CircleShape)
+                .background(type.subColor)
+        )
+        Spacer(modifier = Modifier.width(SpaceLarge))
+        Text(
+            text = type.name,
+            style = Typography.body1,
+            color = if (isSelected) {
+                Color.Black
+            } else {
+                Color.LightGray
+            },
+        )
+        if (isSelected) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                contentAlignment = Alignment.CenterEnd,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = "check",
+                    tint = Color.LightGray,
+                    modifier = Modifier
+                        .size(25.dp),
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SetThemeScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SetThemeScreen.kt
@@ -32,6 +32,7 @@ fun SetThemeScreen(
     navController: NavHostController,
     viewModel: SettingsViewModel,
     selected: String = ThemeType.BasicNight.name,
+    onThemeChanged: (String) -> Unit = {},
 ) {
     var selectedItem by remember { mutableStateOf(selected) }
 
@@ -52,6 +53,7 @@ fun SetThemeScreen(
                 selectedItem = type.name
                 viewModel.setThemeType(type)
                 viewModel.writeTheme(context, type.name)
+                onThemeChanged(type.name)
             }
         )
     }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingScreen.kt
@@ -9,4 +9,5 @@ sealed class SettingScreen(val route: String) {
     object QuizResultsScreen : SettingScreen("quiz_results")
     object ClearCacheScreen : SettingScreen("clear_cache")
     object ReportIssueScreen : SettingScreen("report_issue")
+    object SetThemeScreen : SettingScreen("set_theme")
 }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingTopScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingTopScreen.kt
@@ -37,6 +37,7 @@ fun SettingTopScreen(
     navController: NavController,
     navigationList: List<SettingNavigation>,
     viewModel: SettingsViewModel,
+    uiState: SettingsUiState,
 ) {
     Column(
         modifier = Modifier
@@ -49,12 +50,12 @@ fun SettingTopScreen(
             modifier = Modifier
                 .height(40.dp)
                 .fillMaxWidth()
-                .background(Color.LightGray.copy(alpha = 0.4f))
+                .background(uiState.themeType.subColor)
         )
         LazyColumn {
             item {
                 Divider(
-                    color = Color.LightGray,
+                    color = uiState.themeType.subColor,
                     thickness = 1.dp
                 )
             }
@@ -76,7 +77,7 @@ fun SettingTopScreen(
             modifier = Modifier
                 .height(100.dp)
                 .fillMaxWidth()
-                .background(Color.LightGray.copy(alpha = 0.4f))
+                .background(uiState.themeType.subColor)
         )
 
         val context = LocalContext.current
@@ -87,7 +88,7 @@ fun SettingTopScreen(
             modifier = Modifier
                 .height(40.dp)
                 .fillMaxWidth()
-                .background(Color.LightGray.copy(alpha = 0.4f))
+                .background(uiState.themeType.subColor)
         )
     }
 }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsScreen.kt
@@ -72,7 +72,8 @@ fun SettingsRouting(
         }
         composable(SettingScreen.SetThemeScreen.route) {
             SetThemeScreen(
-                viewModel = viewModel
+                navController = navHostController,
+                viewModel = viewModel,
             )
         }
     }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsScreen.kt
@@ -74,6 +74,7 @@ fun SettingsRouting(
             SetThemeScreen(
                 navController = navHostController,
                 viewModel = viewModel,
+                selected = uiState.themeType.name,
             )
         }
     }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsScreen.kt
@@ -12,7 +12,8 @@ import io.kokoichi.sample.sakamichiapp.presentation.ui.theme.CustomSakaTheme
 
 @Composable
 fun SettingsScreen(
-    viewModel: SettingsViewModel = hiltViewModel()
+    viewModel: SettingsViewModel = hiltViewModel(),
+    onThemeChanged: (String) -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
@@ -23,6 +24,7 @@ fun SettingsScreen(
         SettingsRouting(
             viewModel = viewModel,
             uiState = uiState,
+            onThemeChanged = onThemeChanged,
         )
     }
 }
@@ -30,7 +32,8 @@ fun SettingsScreen(
 @Composable
 fun SettingsRouting(
     viewModel: SettingsViewModel,
-    uiState: SettingsUiState
+    uiState: SettingsUiState,
+    onThemeChanged: (String) -> Unit = {},
 ) {
     val navHostController = rememberNavController()
 
@@ -57,6 +60,7 @@ fun SettingsRouting(
             UpdateBlogScreen(
                 navController = navHostController,
                 viewModel = viewModel,
+                uiState = uiState,
             )
         }
         composable(SettingScreen.QuizResultsScreen.route) {
@@ -81,6 +85,7 @@ fun SettingsRouting(
                 navController = navHostController,
                 viewModel = viewModel,
                 selected = uiState.themeType.name,
+                onThemeChanged = onThemeChanged,
             )
         }
     }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsScreen.kt
@@ -3,6 +3,7 @@ package io.kokoichi.sample.sakamichiapp.presentation.setting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -15,7 +16,9 @@ fun SettingsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
-    // TODO: カスタムテーマカラーを作るならここ？
+    val context = LocalContext.current
+    viewModel.readThemeFromDataStore(context)
+
     CustomSakaTheme {
         SettingsRouting(
             viewModel = viewModel,
@@ -47,6 +50,7 @@ fun SettingsRouting(
                 navController = navHostController,
                 navigationList = navigation,
                 viewModel = viewModel,
+                uiState = uiState,
             )
         }
         composable(SettingScreen.UpdateBlogScreen.route) {
@@ -63,11 +67,13 @@ fun SettingsRouting(
         composable(SettingScreen.ClearCacheScreen.route) {
             CacheClearDialog(
                 navController = navHostController,
+                uiState = uiState,
             )
         }
         composable(SettingScreen.ReportIssueScreen.route) {
             ReportIssueScreen(
                 viewModel = viewModel,
+                uiState = uiState,
             )
         }
         composable(SettingScreen.SetThemeScreen.route) {

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsScreen.kt
@@ -40,6 +40,7 @@ fun SettingsRouting(
             SettingNavigation.QuizResult,
             SettingNavigation.ClearCache,
             SettingNavigation.ReportIssue,
+            SettingNavigation.SetTheme,
         )
         composable(SettingScreen.SettingTopScreen.route) {
             SettingTopScreen(
@@ -67,6 +68,11 @@ fun SettingsRouting(
         composable(SettingScreen.ReportIssueScreen.route) {
             ReportIssueScreen(
                 viewModel = viewModel,
+            )
+        }
+        composable(SettingScreen.SetThemeScreen.route) {
+            SetThemeScreen(
+                viewModel = viewModel
             )
         }
     }
@@ -98,5 +104,10 @@ sealed class SettingNavigation(
     object ReportIssue : SettingNavigation(
         name = "不具合の報告／意見",
         route = SettingScreen.ReportIssueScreen.route
+    )
+
+    object SetTheme : SettingNavigation(
+        name = "テーマカラー設定",
+        route = SettingScreen.SetThemeScreen.route
     )
 }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsUiState.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsUiState.kt
@@ -1,7 +1,13 @@
 package io.kokoichi.sample.sakamichiapp.presentation.setting
 
+import android.content.Context
+import androidx.compose.ui.graphics.Color
+import io.kokoichi.sample.sakamichiapp.presentation.ui.theme.*
+import io.kokoichi.sample.sakamichiapp.presentation.util.DataStoreManager
+
 data class SettingsUiState(
-    val records: MutableList<Record> = mutableListOf()
+    val records: MutableList<Record> = mutableListOf(),
+    val themeType: ThemeType = ThemeType.BasicNight,
 )
 
 data class Record(
@@ -9,3 +15,107 @@ data class Record(
     val correct: Int,
     val total: Int,
 )
+
+sealed class ThemeType(
+    val baseColor: Color,
+    val subColor: Color,
+    val fontColor: Color = Color.White,
+    val name: String,
+) {
+    object BasicNight : ThemeType(
+        baseColor = Color.DarkGray,
+        subColor = Color.LightGray.copy(alpha = 0.4f),
+        fontColor = Color.Black,
+        name = ThemeNames.DEFAULT_NIGHT,
+    )
+
+    object Sakurazaka : ThemeType(
+        baseColor = BaseColorS,
+        subColor = SubColorS,
+        name = ThemeNames.SAKURAZAKA,
+    )
+
+    object Nogizaka : ThemeType(
+        baseColor = BaseColorN,
+        subColor = SubColorN,
+        name = ThemeNames.NOGIZAKA,
+    )
+
+    object Hinata : ThemeType(
+        baseColor = BaseColorH,
+        subColor = SubColorH,
+        name = ThemeNames.HINATAZAKA,
+    )
+
+    object Keyaki : ThemeType(
+        baseColor = BaseColorK,
+        subColor = SubColorK,
+        name = ThemeNames.KEYAKIZAKA,
+    )
+}
+
+object ThemeNames {
+    const val DEFAULT_NIGHT = "夜"
+    const val SAKURAZAKA = "さくら"
+    const val NOGIZAKA = "むらさき"
+    const val HINATAZAKA = "そら"
+    const val KEYAKIZAKA = "みどり"
+}
+
+val themeTypes = listOf(
+    ThemeType.BasicNight,
+    ThemeType.Sakurazaka,
+    ThemeType.Nogizaka,
+    ThemeType.Hinata,
+    ThemeType.Keyaki,
+)
+
+/**
+ * Get BaseColor of ThemeType from DataStore.
+ *
+ * @param context Context
+ * @return BaseColor of the saved themeType
+ */
+suspend fun getBaseColorFromDS(context: Context): Color {
+    val type = DataStoreManager.readString(
+        context = context,
+        key = DataStoreManager.KEY_THEME_GROUP,
+    )
+    return getBaseColorInThemeTypesFromString(type)
+}
+
+/**
+ * Get SubColor of ThemeType from DataStore.
+ *
+ * @param context Context
+ * @return SubColor of the saved themeType
+ */
+suspend fun getSubColorFromDS(context: Context): Color {
+    val type = DataStoreManager.readString(
+        context = context,
+        key = DataStoreManager.KEY_THEME_GROUP,
+    )
+    return getSubColorInThemeTypesFromString(type)
+}
+
+/**
+ * Get BaseColor from String of ThemeType.name.
+ *
+ * @param type String of ThemeType.name
+ * @return BaseColor (if the name exists), BaseColor of BasicNight (else)
+ */
+fun getBaseColorInThemeTypesFromString(type: String): Color {
+    val theme = themeTypes.firstOrNull { it.name == type }
+    return theme?.baseColor ?: ThemeType.BasicNight.baseColor
+}
+
+/**
+ * Get SubColor from String of ThemeType.name.
+ *
+ * @param type String of ThemeType.name
+ * @return SubColor (if the name exists), BaseColor of BasicNight (else)
+ */
+fun getSubColorInThemeTypesFromString(type: String): Color {
+    val theme = themeTypes.firstOrNull { it.name == type }
+    return theme?.subColor ?: ThemeType.BasicNight.subColor
+}

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsViewModel.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsViewModel.kt
@@ -74,4 +74,43 @@ class SettingsViewModel @Inject constructor(
             }
         }
     }
+
+    fun writeTheme(
+        context: Context,
+        theme: String,
+    ) {
+        viewModelScope.launch {
+            async {
+                DataStoreManager.writeString(
+                    context,
+                    DataStoreManager.KEY_THEME_GROUP,
+                    theme,
+                )
+            }
+        }
+    }
+
+    fun readThemeFromDataStore(context: Context) {
+        viewModelScope.launch {
+            val res = async {
+                DataStoreManager.readString(context, DataStoreManager.KEY_THEME_GROUP)
+            }
+            setThemeType(res.await())
+        }
+    }
+
+    fun setThemeType(typeStr: String) {
+        val type = themeTypes
+            .firstOrNull { it.name == typeStr }
+
+        _uiState.update {
+            it.copy(
+                themeType = type ?: ThemeType.BasicNight
+            )
+        }
+    }
+
+    fun setThemeType(type: ThemeType) {
+        _uiState.update { it.copy(themeType = type) }
+    }
 }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/UpdateBlogScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/UpdateBlogScreen.kt
@@ -17,17 +17,16 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import io.kokoichi.sample.sakamichiapp.R
-import io.kokoichi.sample.sakamichiapp.presentation.ui.theme.SubColorS
 import io.kokoichi.sample.sakamichiapp.presentation.util.Constants.BottomBarPadding
 import io.kokoichi.sample.sakamichiapp.presentation.util.DataStoreManager
 import io.kokoichi.sample.sakamichiapp.presentation.util.TestTags
-import io.kokoichi.sample.sakamichiapp.presentation.util.getSubColor
 import kotlinx.coroutines.async
 
 @Composable
 fun UpdateBlogScreen(
     navController: NavHostController,
-    viewModel: SettingsViewModel
+    viewModel: SettingsViewModel,
+    uiState: SettingsUiState,
 ) {
 
     val context = LocalContext.current
@@ -51,7 +50,7 @@ fun UpdateBlogScreen(
                 .fillMaxSize()
                 .padding(20.dp)
                 .clip(RoundedCornerShape(20.dp))
-                .background(getSubColor("SAKURAZAKA").copy(alpha = 0.4f))
+                .background(uiState.themeType.subColor)
                 .padding(10.dp)
         ) {
             Column {
@@ -89,7 +88,7 @@ fun UpdateBlogScreen(
                         .background(Color.White)
                         .border(
                             width = 1.dp,
-                            color = SubColorS,
+                            color = uiState.themeType.baseColor,
                             shape = buttonShape
                         )
                         .testTag(TestTags.UPDATE_BLOG_OK_BUTTON),
@@ -99,7 +98,7 @@ fun UpdateBlogScreen(
                 ) {
                     Text(
                         text = stringResource(R.string.update_blog_button_ok),
-                        color = SubColorS,
+                        color = uiState.themeType.baseColor,
                     )
                 }
 
@@ -113,7 +112,7 @@ fun UpdateBlogScreen(
                         .background(Color.White)
                         .border(
                             width = 1.dp,
-                            color = SubColorS,
+                            color = uiState.themeType.baseColor,
                             shape = buttonShape
                         ),
                     onClick = {
@@ -122,7 +121,7 @@ fun UpdateBlogScreen(
                 ) {
                     Text(
                         text = stringResource(R.string.update_blog_button_cancel),
-                        color = SubColorS,
+                        color = uiState.themeType.baseColor,
                     )
                 }
             }
@@ -136,6 +135,7 @@ fun UpdateBlogScreen(
             CheckDialog(
                 title = stringResource(R.string.update_blog_success_dialog_title),
                 body = stringResource(R.string.update_blog_success_dialog_body),
+                buttonColor = uiState.themeType.subColor,
                 onButtonClicked = {
                     openDialog = !openDialog
                 },
@@ -145,6 +145,7 @@ fun UpdateBlogScreen(
             CheckDialog(
                 title = stringResource(R.string.update_blog_failure_dialog_title),
                 body = stringResource(R.string.update_blog_failure_dialog_body),
+                buttonColor = uiState.themeType.subColor,
                 onButtonClicked = {
                     openDialog = !openDialog
                 },
@@ -157,6 +158,7 @@ fun UpdateBlogScreen(
 fun CheckDialog(
     title: String,
     body: String,
+    buttonColor: Color,
     onButtonClicked: () -> Unit = {},
 ) {
     Surface(
@@ -192,7 +194,7 @@ fun CheckDialog(
                         modifier = Modifier
                             .weight(1f)
                             .clip(RoundedCornerShape(5.dp))
-                            .background(SubColorS)
+                            .background(buttonColor)
                             .testTag(TestTags.UPDATE_BLOG_DIALOG_OK_BUTTON),
                         onClick = {
                             onButtonClicked()

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/ui/theme/Color.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/ui/theme/Color.kt
@@ -13,3 +13,7 @@ val SubColorS = Color(0x99F19DB5)
 // Nogizaka
 val BaseColorN = Color(0xFF742581)
 val SubColorN = Color(0x99742581)
+
+// Keyaki
+val BaseColorK = Color(0xFF77c059)
+val SubColorK = Color(0x99b9df90)

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/BottomNavigation.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/BottomNavigation.kt
@@ -28,13 +28,18 @@ import io.kokoichi.sample.sakamichiapp.presentation.member_list.MemberListScreen
 import io.kokoichi.sample.sakamichiapp.presentation.positions.PositionsScreen
 import io.kokoichi.sample.sakamichiapp.presentation.quiz.QuizScreen
 import io.kokoichi.sample.sakamichiapp.presentation.setting.SettingsScreen
+import io.kokoichi.sample.sakamichiapp.presentation.setting.getBaseColorInThemeTypesFromString
+import io.kokoichi.sample.sakamichiapp.presentation.setting.getSubColorInThemeTypesFromString
 import io.kokoichi.sample.sakamichiapp.presentation.util.components.WebViewWidget
 
 /**
  * Bottom navigation host setup (Register routing).
  */
 @Composable
-fun BottomNavHost(navHostController: NavHostController) {
+fun BottomNavHost(
+    navHostController: NavHostController,
+    onThemeChanged: (String) -> Unit
+) {
     // Change color of ActionBar using systemuicontroller.
     val systemUiController = rememberSystemUiController()
     systemUiController.setSystemBarsColor(
@@ -108,7 +113,9 @@ fun BottomNavHost(navHostController: NavHostController) {
         composable(
             Screen.SettingScreen.route
         ) {
-            SettingsScreen()
+            SettingsScreen(
+                onThemeChanged = onThemeChanged,
+            )
         }
 
         /**
@@ -141,9 +148,15 @@ fun BottomNavigationBar(
     navController: NavController,
     items: List<BottomNavItem>,
     modifier: Modifier = Modifier,
+    themeType: String = "",
 ) {
     val backStackEntry = navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry.value?.destination?.route
+
+    // Colors used for bottom bar
+    val selectedColor = getBaseColorInThemeTypesFromString(themeType)
+    val unSelectedColor = getSubColorInThemeTypesFromString(themeType).copy(alpha = 0.4f)
+
     BottomNavigation(
         modifier = modifier,
         backgroundColor = Color.White,
@@ -164,8 +177,8 @@ fun BottomNavigationBar(
                         navController.navigate(item.route)
                     }
                 },
-                selectedContentColor = Color.DarkGray,
-                unselectedContentColor = Color.LightGray,
+                selectedContentColor = selectedColor,
+                unselectedContentColor = unSelectedColor,
                 icon = {
                     Column(horizontalAlignment = CenterHorizontally) {
                         if (item.badgeCount > 0) {
@@ -190,9 +203,9 @@ fun BottomNavigationBar(
                             textAlign = TextAlign.Center,
                             fontSize = 10.sp,
                             color = if (selected) {
-                                Color.DarkGray
+                                selectedColor
                             } else {
-                                Color.LightGray
+                                unSelectedColor
                             },
                         )
                     }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/DataStoreManager.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/DataStoreManager.kt
@@ -23,6 +23,7 @@ object DataStoreManager {
      * Key sets for Data store.
      */
     const val KEY_IS_DEVELOPER = "is_developer"
+    const val KEY_THEME_GROUP = "theme_type"
 
     suspend fun writeBoolean(context: Context, key: String, value: Boolean) =
         withContext(Dispatchers.IO) {

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/Navigation.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/Navigation.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.async
 
 /**
  * Compose navigation set-up.
@@ -17,6 +19,18 @@ import androidx.navigation.compose.rememberNavController
 @Composable
 fun Navigation() {
     val navController = rememberNavController()
+
+    val context = LocalContext.current
+
+    // Theme type shared globally
+    var themeType by remember { mutableStateOf("") }
+    LaunchedEffect(Unit) {
+        // Read
+        val storeVal = async {
+            DataStoreManager.readString(context, DataStoreManager.KEY_THEME_GROUP)
+        }
+        themeType = storeVal.await()
+    }
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -32,10 +46,15 @@ fun Navigation() {
                         BottomNavItem.Position,
                         BottomNavItem.Quiz,
                         BottomNavItem.Setting,
-                    )
+                    ),
+                    themeType = themeType,
                 )
             }) {
-            BottomNavHost(navHostController = navController)
+            BottomNavHost(
+                navHostController = navController,
+            ) {
+                themeType = it
+            }
         }
     }
 }

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/TestTags.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/TestTags.kt
@@ -45,6 +45,11 @@ object TestTags {
     const val REPORT_ISSUE_DIALOG_OK = "REPORT_ISSUE_DIALOG_OK"
     const val REPORT_ISSUE_DIALOG_CANCEL = "REPORT_ISSUE_DIALOG_CANCEL"
 
+    // SetTheme Screen
+    const val SET_THEME_TITLE = "SET_THEME_TITLE"
+    const val SET_THEME_BACK_ARROW = "SET_THEME_BACK_ARROW"
+    const val SET_THEME_THEME = "SET_THEME_THEME"
+
     // Utils
     const val GROUP_BAR = "GROUP_BAR"
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,4 +59,7 @@
     <string name="report_issue_dialog_body">内容をご確認ください</string>
     <string name="report_issue_dialog_button_ok">送信</string>
     <string name="report_issue_dialog_button_cancel">キャンセル</string>
+
+    <!--    Strings for SetThemeScreen-->
+    <string name="set_theme_title">テーマカラー</string>
 </resources>


### PR DESCRIPTION
## Issue 番号
Closes #40

## 対応内容・対応背景
- テーマカラー設定のページを作成
  - テーマカラーを取得するメソッド等作成
- セッティング内数カ所にカスタムカラーに設定
- Bottom Bar にカスタムカラーを設定

## やってないこと
- トップバーとボトムバー（の下）に色を付け加えると少しビジーになるかと思い、白のままにした

## UI before / after

### 設定ページ
<img width="313" alt="スクリーンショット 2021-11-24 21 18 16" src="https://user-images.githubusercontent.com/52474650/143237086-1ff8d1fb-c7bf-452e-882b-53854733135e.png">

### 全体の見た目
<img width="310" alt="スクリーンショット 2021-11-24 21 17 56" src="https://user-images.githubusercontent.com/52474650/143237035-7a7b740e-2df2-49b0-ab8b-18c6e9eca09a.png">

## テスト観点

### 設定ページ
- きちんと情報が表示されているか
- 列をクリックした時に"のみ"設定変更する関数が走るか
- 戻る矢印ボタンをクリックしたら上のスタックに navigation するか

## 補足
