### PR TITLE
Issue/57

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion '1.5.21'
+        kotlinCompilerVersion '1.6'
     }
     packagingOptions {
         resources {
@@ -71,7 +71,7 @@ dependencies {
 
     // Compose dependencies
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha07"
-    implementation "androidx.navigation:navigation-compose:2.4.0-alpha08"
+    implementation "androidx.navigation:navigation-compose:2.4.0-beta02"
     implementation "com.google.accompanist:accompanist-flowlayout:0.17.0"
 
     // Retrofit
@@ -141,6 +141,8 @@ dependencies {
 
     // Action bar helper
     implementation "com.google.accompanist:accompanist-systemuicontroller:0.17.0"
+    // Animated navigation
+    implementation "com.google.accompanist:accompanist-navigation-animation:0.20.2"
 
     // DataStore
     implementation "androidx.datastore:datastore-preferences:1.0.0"

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/MainActivity.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/MainActivity.kt
@@ -3,6 +3,7 @@ package io.kokoichi.sample.sakamichiapp.presentation
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material.ExperimentalMaterialApi
 import dagger.hilt.android.AndroidEntryPoint
 import io.kokoichi.sample.sakamichiapp.presentation.util.Navigation
@@ -10,6 +11,7 @@ import io.kokoichi.sample.sakamichiapp.presentation.util.Navigation
 @ExperimentalMaterialApi
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @ExperimentalAnimationApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/SettingsScreen.kt
@@ -1,16 +1,22 @@
 package io.kokoichi.sample.sakamichiapp.presentation.setting
 
+import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
+import com.google.accompanist.navigation.animation.composable
+import com.google.accompanist.navigation.animation.AnimatedNavHost
+import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import io.kokoichi.sample.sakamichiapp.presentation.setting.pages.*
 import io.kokoichi.sample.sakamichiapp.presentation.ui.theme.CustomSakaTheme
+import io.kokoichi.sample.sakamichiapp.presentation.util.Constants
 
+@ExperimentalAnimationApi
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel(),
@@ -30,17 +36,31 @@ fun SettingsScreen(
     }
 }
 
+@ExperimentalAnimationApi
 @Composable
 fun SettingsRouting(
     viewModel: SettingsViewModel,
     uiState: SettingsUiState,
     onThemeChanged: (String) -> Unit = {},
 ) {
-    val navHostController = rememberNavController()
+    val navController = rememberAnimatedNavController()
 
-    NavHost(
-        navController = navHostController,
+    AnimatedNavHost(
+        navController,
+        modifier = Modifier.fillMaxSize(),
         startDestination = SettingScreen.SettingTopScreen.route,
+        enterTransition = { _, _ ->
+            slideIntoContainer(
+                AnimatedContentScope.SlideDirection.Left,
+                animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS)
+            ) + fadeIn(animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS))
+        },
+        popExitTransition = { _, _ ->
+            slideOutOfContainer(
+                AnimatedContentScope.SlideDirection.Right,
+                animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS)
+            ) + fadeOut(animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS))
+        },
     ) {
         val navigation = listOf(
             SettingNavigation.UpdateBlog,
@@ -50,9 +70,24 @@ fun SettingsRouting(
             SettingNavigation.SetTheme,
             SettingNavigation.ShareApp,
         )
-        composable(SettingScreen.SettingTopScreen.route) {
+
+        composable(
+            route = SettingScreen.SettingTopScreen.route,
+            exitTransition = { _, _ ->
+                slideOutOfContainer(
+                    AnimatedContentScope.SlideDirection.Left,
+                    animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS)
+                ) + fadeOut(animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS))
+            },
+            popEnterTransition = { _, _ ->
+                slideIntoContainer(
+                    AnimatedContentScope.SlideDirection.Right,
+                    animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS)
+                ) + fadeIn(animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS))
+            }
+        ) {
             SettingTopScreen(
-                navController = navHostController,
+                navController = navController,
                 navigationList = navigation,
                 viewModel = viewModel,
                 uiState = uiState,
@@ -60,7 +95,7 @@ fun SettingsRouting(
         }
         composable(SettingScreen.UpdateBlogScreen.route) {
             UpdateBlogScreen(
-                navController = navHostController,
+                navController = navController,
                 viewModel = viewModel,
                 uiState = uiState,
             )
@@ -72,7 +107,7 @@ fun SettingsRouting(
         }
         composable(SettingScreen.ClearCacheScreen.route) {
             CacheClearDialog(
-                navController = navHostController,
+                navController = navController,
                 uiState = uiState,
             )
         }
@@ -84,7 +119,7 @@ fun SettingsRouting(
         }
         composable(SettingScreen.SetThemeScreen.route) {
             SetThemeScreen(
-                navController = navHostController,
+                navController = navController,
                 viewModel = viewModel,
                 selected = uiState.themeType.name,
                 onThemeChanged = onThemeChanged,

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/pages/SetThemeScreen.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/setting/pages/SetThemeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
@@ -88,12 +89,19 @@ fun ThemeTopBar(
             contentDescription = stringResource(R.string.back_arrow),
             tint = themeType.fontColor,
             modifier = Modifier
-                .size(IconSizeMedium)
+                .size(
+                    width = IconSizeMedium + SpaceTiny + SpaceTiny,
+                    height = IconSizeMedium + SpaceTiny
+                )
+                .clip(RoundedCornerShape(SpaceTiny))
                 .clickable {
                     onArrowClick()
                 }
+                .padding(end = SpaceTiny)
+                .padding(SpaceTiny / 2)
                 .testTag(TestTags.SET_THEME_BACK_ARROW),
-        )
+            )
+
     }
 }
 

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/BottomNavigation.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/BottomNavigation.kt
@@ -1,6 +1,7 @@
 package io.kokoichi.sample.sakamichiapp.presentation.util
 
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ import io.kokoichi.sample.sakamichiapp.presentation.util.components.WebViewWidge
 /**
  * Bottom navigation host setup (Register routing).
  */
+@ExperimentalAnimationApi
 @Composable
 fun BottomNavHost(
     navHostController: NavHostController,

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/Constants.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/Constants.kt
@@ -57,6 +57,8 @@ object Constants {
     // =========== Setting Screen ===========
     const val MAX_REPORT_ISSUE_BODY_LINES = 4
 
+    const val NAVIGATION_DURATION_MILLIS = 600
+
     // version in settings
     const val NEED_TAP_NUM_TO_SHOW_SNACK_BAR = 2
     const val NEED_TAP_NUM_TO_BE_DEVELOPER = 7

--- a/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/Navigation.kt
+++ b/app/src/main/java/io/kokoichi/sample/sakamichiapp/presentation/util/Navigation.kt
@@ -1,5 +1,6 @@
 package io.kokoichi.sample.sakamichiapp.presentation.util
 
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.ExperimentalMaterialApi
@@ -15,6 +16,7 @@ import kotlinx.coroutines.async
 /**
  * Compose navigation set-up.
  */
+@ExperimentalAnimationApi
 @ExperimentalMaterialApi
 @Composable
 fun Navigation() {


### PR DESCRIPTION
## Issue 番号
57

## 対応内容・対応背景
- 

## やったこと
- テーマカラー設定画面の、戻るボタンのクリック時の背景（ripple）の形を変更
- navigation 時に、ページをめくるような遷移をさせるよう変更

## やってないこと
- ページの捲られ方のテスト？

## UI before / after

### ripple 見た目
<img width="672" alt="スクリーンショット 2021-12-03 20 17 29" src="https://user-images.githubusercontent.com/52474650/144593887-70a4f5dc-fc29-4994-8dbe-0e941dca10ef.png">

### ナビゲーションの動画
https://user-images.githubusercontent.com/52474650/144594117-cbcee266-dc09-4b4b-8132-55e9de078164.mov


## 補足
Closes #57 
