### PR TITLE
表示に時間がかかる問題を解決する

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+Sakamichi app

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -3,7 +3,35 @@
   <component name="AndroidTestResultsUserPreferences">
     <option name="androidTestResultsTableState">
       <map>
+        <entry key="-1940715936">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Google&#10; Pixel 3" value="120" />
+                  <entry key="Tests" value="360" />
+                  <entry key="adb-8BSX1EC56-SlLKka._adb-tls-connect._tcp." value="120" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="130782490">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Google&#10; Pixel 3" value="120" />
+                  <entry key="Tests" value="360" />
+                  <entry key="adb-8BSX1EC56-SlLKka._adb-tls-connect._tcp." value="120" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1808212153">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="11" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="testRunner" value="GRADLE" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="11" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/app" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,12 +9,12 @@ plugins {
 def applicationName = "SakamichiApp"
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "jp.mydns.kokoichi0206.sakamichiapp"
         minSdk 26
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.1.9"
 
@@ -58,14 +58,12 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
-        useIR = true
     }
     buildFeatures {
         compose true
     }
     composeOptions {
         kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion '1.6'
     }
     packagingOptions {
         resources {
@@ -120,8 +118,8 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit-mock:$retrofit_version"
 
     // Room
-    implementation "androidx.room:room-runtime:2.3.0"
-    kapt "androidx.room:room-compiler:2.3.0"
+    implementation "androidx.room:room-runtime:2.4.3"
+    kapt "androidx.room:room-compiler:2.4.3"
 
     // Kotlin Extensions and Coroutines support for Room
     implementation "androidx.room:room-ktx:2.3.0"
@@ -134,21 +132,20 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3'
 
     // Coroutine Lifecycle Scopes
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
 
     // Coil
-    implementation("io.coil-kt:coil-compose:1.4.0")
+    implementation("io.coil-kt:coil-compose:2.2.2")
 
     // Dagger - Hilt
-    implementation "com.google.dagger:hilt-android:2.38.1"
-    kapt "com.google.dagger:hilt-android-compiler:2.37"
-    implementation "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03"
+    implementation "com.google.dagger:hilt-android:2.42"
+    kapt "com.google.dagger:hilt-android-compiler:2.42"
     kapt "androidx.hilt:hilt-compiler:1.0.0"
-    implementation 'androidx.hilt:hilt-navigation-compose:1.0.0-alpha03'
+    implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'
 
     androidTestImplementation 'com.google.dagger:hilt-android-testing:2.37'
-    kaptAndroidTest 'com.google.dagger:hilt-android-compiler:2.37'
+    kaptAndroidTest 'com.google.dagger:hilt-android-compiler:2.42'
 
     // Local Unit Tests
     implementation "androidx.test:core:1.4.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,7 @@ android {
         versionCode 1
         versionName "1.1.9"
 
+        testApplicationId "jp.mydns.kokoichi0206.sakamichiapp.test"
         testInstrumentationRunner "jp.mydns.kokoichi0206.sakamichiapp.HiltTestRunner"
         vectorDrawables {
             useSupportLibrary true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,7 +179,7 @@ dependencies {
     // Action bar helper
     implementation "com.google.accompanist:accompanist-systemuicontroller:0.17.0"
     // Animated navigation
-    implementation "com.google.accompanist:accompanist-navigation-animation:0.20.2"
+    implementation "com.google.accompanist:accompanist-navigation-animation:0.26.5-rc"
 
     // DataStore
     implementation "androidx.datastore:datastore-preferences:1.0.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,6 +75,9 @@ android {
             force 'junit:junit:4.13.2'
         }
     }
+    lint {
+        baseline = file("lint-baseline.xml")
+    }
 }
 
 dokkaGfm.configure {
@@ -125,7 +128,7 @@ dependencies {
     implementation "androidx.room:room-ktx:2.3.0"
 
     // Timber
-    implementation 'com.jakewharton.timber:timber:4.7.1'
+    implementation 'com.jakewharton.timber:timber:5.0.1'
 
     // Coroutines
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3'

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues name="AGP (7.3.1)" by="lint 7.3.1" client="gradle" dependencies="false" format="6" type="baseline" variant="all"
+    version="7.3.1">
+
+    <issue id="LintError"
+        message="The lint detector&#xA;    `timber.lint.WrongTimberUsageDetector`&#xA;called `context.getMainProject()` during module analysis.&#xA;&#xA;This does not work correctly when running in AGP (7.3.1).&#xA;&#xA;In particular, there may be false positives or false negatives because&#xA;the lint check may be using the minSdkVersion or manifest information&#xA;from the library instead of any consuming app module.&#xA;&#xA;Contact the vendor of the lint issue to get it fixed/updated (if&#xA;known, listed below), and in the meantime you can try to work around&#xA;this by disabling the following issues:&#xA;&#xA;&quot;LogNotTimber&quot;,&quot;StringFormatInTimber&quot;,&quot;ThrowableNotAtBeginning&quot;,&quot;BinaryOperationInTimber&quot;,&quot;TimberArgCount&quot;,&quot;TimberArgTypes&quot;,&quot;TimberTagLength&quot;,&quot;TimberExceptionLogging&quot;&#xA;&#xA;Issue Vendors:&#xA;Identifier: jetified-timber-4.7.1&#xA;&#xA;Call stack: Context.getMainProject(Context.kt:115)←WrongTimberUsageDetector.visitMethod(WrongTimberUsageDetector.java:80)←Detector.visitMethodCall(Detector.kt:549)←UElementVisitor$DelegatingPsiVisitor.visitMethodCallExpression(UElementVisitor.kt:1096)←UElementVisitor$DelegatingPsiVisitor.visitCallExpression(UElementVisitor.kt:1076)←KotlinUFunctionCallExpression.accept(KotlinUFunctionCallExpression.kt:164)←UQualifiedReferenceExpression$DefaultImpls.accept(UQualifiedReferenceExpression.kt:34)←KotlinUQualifiedReferenceExpression.accept(KotlinUQualifiedReferenceExpression.kt:11)←UQualifiedReferenceExpression$DefaultImpls.accept(UQualifiedReferenceExpression.kt:33)←KotlinUQualifiedReferenceExpression.accept(KotlinUQualifiedReferenceExpression.kt:11)←ImplementationUtilsKt.acceptList(implementationUtils.kt:29)←UBlockExpression$DefaultImpls.accept(UBlockExpression.kt:21)←KotlinUBlockExpression.accept(KotlinUBlockExpression.kt:11)←UMethod$DefaultImpls.accept(UMethod.kt:45)←KotlinUMethod.accept(KotlinUMethod.kt:21)←ImplementationUtilsKt.acceptList(implementationUtils.kt:29)←AbstractKotlinUClass.accept(AbstractKotlinUClass.kt:42)←ImplementationUtilsKt.acceptList(implementationUtils.kt:29)←UFile$DefaultImpls.accept(UFile.kt:87)←KotlinUFile.accept(KotlinUFile.kt:14)">
+        <location file="src/main/java/jp/mydns/kokoichi0206/sakamichiapp/data/remote/LoggingInterceptor.kt" />
+    </issue>
+
+    <issue errorLine1="            android:label=&quot;@string/app_name&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" id="RedundantLabel"
+        message="Redundant label can be removed">
+        <location column="13" file="src/main/AndroidManifest.xml" line="19" />
+    </issue>
+
+    <issue errorLine1="" errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" id="GradleDependency"
+        message="A newer version of androidx.core:core-ktx than 1.6.0 is available: 1.9.0">
+        <location column="20" file="build.gradle" line="93" />
+    </issue>
+
+    <issue errorLine1="dependencies {" errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        id="GradleDependency" message="A newer version of androidx.appcompat:appcompat than 1.3.1 is available: 1.5.1">
+        <location column="20" file="build.gradle" line="94" />
+    </issue>
+
+    <issue errorLine1="" errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        id="GradleDependency"
+        message="A newer version of com.google.android.material:material than 1.4.0 is available: 1.7.0">
+        <location column="20" file="build.gradle" line="95" />
+    </issue>
+
+    <issue errorLine1="    implementation &quot;androidx.compose.ui:ui:$compose_version&quot;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-runtime-ktx than 2.3.1 is available: 2.5.1">
+        <location column="20" file="build.gradle" line="99" />
+    </issue>
+
+    <issue errorLine1="    implementation &quot;androidx.compose.material:material:$compose_version&quot;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" id="GradleDependency"
+        message="A newer version of androidx.activity:activity-compose than 1.3.1 is available: 1.6.0">
+        <location column="20" file="build.gradle" line="100" />
+    </issue>
+
+    <issue errorLine1="    implementation &apos;androidx.lifecycle:lifecycle-runtime-ktx:2.3.1&apos;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" id="GradleDependency"
+        message="A newer version of androidx.navigation:navigation-testing than 2.3.5 is available: 2.5.2">
+        <location column="20" file="build.gradle" line="102" />
+    </issue>
+
+    <issue errorLine1="    debugImplementation &quot;androidx.compose.ui:ui-tooling:$compose_version&quot;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-compose than 1.0.0-alpha07 is available: 2.6.0-alpha02">
+        <location column="20" file="build.gradle" line="107" />
+    </issue>
+
+    <issue errorLine1="" errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        id="GradleDependency"
+        message="A newer version of androidx.navigation:navigation-compose than 2.4.0-beta02 is available: 2.6.0-alpha02">
+        <location column="20" file="build.gradle" line="108" />
+    </issue>
+
+    <issue errorLine1="    implementation &quot;com.squareup.retrofit2:retrofit:$retrofit_version&quot;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" id="GradleDependency"
+        message="A newer version of com.squareup.okhttp3:okhttp than 4.9.0 is available: 4.10.0">
+        <location column="20" file="build.gradle" line="116" />
+    </issue>
+
+    <issue errorLine1="    kapt &quot;androidx.room:room-compiler:2.4.3&quot;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" id="GradleDependency"
+        message="A newer version of androidx.room:room-ktx than 2.3.0 is available: 2.4.3">
+        <location column="20" file="build.gradle" line="125" />
+    </issue>
+
+    <issue errorLine1="    implementation &apos;com.jakewharton.timber:timber:4.7.1&apos;"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" id="GradleDependency"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-core than 1.4.3 is available: 1.6.4">
+        <location column="20" file="build.gradle" line="131" />
+    </issue>
+
+    <issue errorLine1="" errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        id="GradleDependency"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-android than 1.4.3 is available: 1.6.4">
+        <location column="20" file="build.gradle" line="132" />
+    </issue>
+
+    <issue errorLine1="    testImplementation &quot;org.hamcrest:hamcrest-all:1.3&quot;"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" id="GradleDependency"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-test than 1.5.0 is available: 1.5.2">
+        <location column="24" file="build.gradle" line="156" />
+    </issue>
+
+    <issue errorLine1=""
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        id="GradleDependency"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-test than 1.5.0 is available: 1.5.2">
+        <location column="31" file="build.gradle" line="165" />
+    </issue>
+
+    <issue errorLine1="    implementation &quot;androidx.datastore:datastore-preferences-rxjava3:1.0.0&quot;"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" id="GradleDependency"
+        message="A newer version of org.xerial:sqlite-jdbc than 3.34.0 is available: 3.36.0">
+        <location column="10" file="build.gradle" line="186" />
+    </issue>
+
+    <issue errorLine1="            }) {" errorLine2="               ^" id="UnusedMaterialScaffoldPaddingParameter"
+        message="Content padding parameter it is not used">
+        <location column="16" file="src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/util/Navigation.kt"
+            line="54" />
+    </issue>
+
+    <issue
+        errorLine1="    &lt;string name=&quot;developer_on_the_way_snack_bar_text&quot;>You are now %d steps away from being a developer.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;steps&quot;): This should probably be a plural rather than a string">
+        <location column="5" file="src/main/res/values/strings.xml" line="40" />
+    </issue>
+
+    <issue id="ObsoleteSdkInt"
+        message="This folder configuration (`v24`) is unnecessary; `minSdkVersion` is 26. Merge all the resources in this folder into `drawable`.">
+        <location file="src/main/res/drawable-v24" />
+    </issue>
+
+    <issue id="ObsoleteSdkInt"
+        message="This folder configuration (`v26`) is unnecessary; `minSdkVersion` is 26. Merge all the resources in this folder into `mipmap-anydpi`.">
+        <location file="src/main/res/mipmap-anydpi-v26" />
+    </issue>
+
+    <issue
+        errorLine1="        &lt;item name=&quot;android:statusBarColor&quot; tools:targetApi=&quot;l&quot;>?attr/colorPrimaryVariant&lt;/item>"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~" id="ObsoleteSdkInt"
+        message="Unnecessary; SDK_INT is always >= 21">
+        <location column="45" file="src/main/res/values-night/themes.xml" line="13" />
+    </issue>
+
+    <issue
+        errorLine1="        &lt;item name=&quot;android:statusBarColor&quot; tools:targetApi=&quot;l&quot;>?attr/colorPrimaryVariant&lt;/item>"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~" id="ObsoleteSdkInt"
+        message="Unnecessary; SDK_INT is always >= 21">
+        <location column="45" file="src/main/res/values/themes.xml" line="13" />
+    </issue>
+
+    <issue
+        errorLine1="      android:pathData=&quot;M19.14,12.94c0.04,-0.3 0.06,-0.61 0.06,-0.94c0,-0.32 -0.02,-0.64 -0.07,-0.94l2.03,-1.58c0.18,-0.14 0.23,-0.41 0.12,-0.61l-1.92,-3.32c-0.12,-0.22 -0.37,-0.29 -0.59,-0.22l-2.39,0.96c-0.5,-0.38 -1.03,-0.7 -1.62,-0.94L14.4,2.81c-0.04,-0.24 -0.24,-0.41 -0.48,-0.41h-3.84c-0.24,0 -0.43,0.17 -0.47,0.41L9.25,5.35C8.66,5.59 8.12,5.92 7.63,6.29L5.24,5.33c-0.22,-0.08 -0.47,0 -0.59,0.22L2.74,8.87C2.62,9.08 2.66,9.34 2.86,9.48l2.03,1.58C4.84,11.36 4.8,11.69 4.8,12s0.02,0.64 0.07,0.94l-2.03,1.58c-0.18,0.14 -0.23,0.41 -0.12,0.61l1.92,3.32c0.12,0.22 0.37,0.29 0.59,0.22l2.39,-0.96c0.5,0.38 1.03,0.7 1.62,0.94l0.36,2.54c0.05,0.24 0.24,0.41 0.48,0.41h3.84c0.24,0 0.44,-0.17 0.47,-0.41l0.36,-2.54c0.59,-0.24 1.13,-0.56 1.62,-0.94l2.39,0.96c0.22,0.08 0.47,0 0.59,-0.22l1.92,-3.32c0.12,-0.22 0.07,-0.47 -0.12,-0.61L19.14,12.94zM12,15.6c-1.98,0 -3.6,-1.62 -3.6,-3.6s1.62,-3.6 3.6,-3.6s3.6,1.62 3.6,3.6S13.98,15.6 12,15.6z&quot;/>"
+        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        id="VectorPath"
+        message="Very long vector path (904 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector.">
+        <location column="25" file="src/main/res/drawable/settings.xml" line="9" />
+    </issue>
+
+    <issue errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;" errorLine2="^"
+        id="UnusedResources" message="The resource `R.drawable.ic_launcher_foreground` appears to be unused">
+        <location column="1" file="src/main/res/drawable-v24/ic_launcher_foreground.xml" line="1" />
+    </issue>
+
+    <issue
+        errorLine1="    &lt;style name=&quot;Theme.SakamichiApp.AppBarOverlay&quot; parent=&quot;ThemeOverlay.AppCompat.Dark.ActionBar&quot; />"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" id="UnusedResources"
+        message="The resource `R.style.Theme_SakamichiApp_AppBarOverlay` appears to be unused">
+        <location column="12" file="src/main/res/values/themes.xml" line="22" />
+    </issue>
+
+    <issue
+        errorLine1="    &lt;style name=&quot;Theme.SakamichiApp.PopupOverlay&quot; parent=&quot;ThemeOverlay.AppCompat.Light&quot; />"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" id="UnusedResources"
+        message="The resource `R.style.Theme_SakamichiApp_PopupOverlay` appears to be unused">
+        <location column="12" file="src/main/res/values/themes.xml" line="24" />
+    </issue>
+
+    <issue id="IconLocation" message="Found bitmap drawable `res/drawable/link_to_apk.png` in densityless folder">
+        <location file="src/main/res/drawable/link_to_apk.png" />
+    </issue>
+
+</issues>

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.package">
+    package="jp.mydns.kokoichi0206.sakamichiapp.test">
 
     <application android:extractNativeLibs="true" />
 </manifest>

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/AppEndToEnd.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/AppEndToEnd.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.sakamichiapp
 
+import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -43,7 +44,7 @@ class AppEndToEnd {
         hiltRule.inject()
 
         // Use real navigation (not mockk)
-        composeRule.setContent {
+        composeRule.activity.setContent {
             Navigation()
         }
     }

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogScreenTest.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.blog
 
+import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -41,7 +42,7 @@ class BlogScreenTest {
         hiltRule.inject()
         MockKAnnotations.init(this)
 
-        composeRule.setContent {
+        composeRule.activity.setContent {
             BlogScreenWithCustomTheme(
                 navController = navController,
             )

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListScreenTest.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list
 
+import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
@@ -44,7 +45,7 @@ class MemberListScreenTest {
         hiltRule.inject()
         MockKAnnotations.init(this)
 
-        composeRule.setContent {
+        composeRule.activity.setContent {
             MemberListScreen(
                 navController = navController,
             )

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/quiz/PlayQuizScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/quiz/PlayQuizScreenTest.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.quiz
 
+import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -32,7 +33,7 @@ class PlayQuizScreenTest {
     fun setUp() {
         hiltRule.inject()
 
-        composeRule.setContent {
+        composeRule.activity.setContent {
             QuizScreen()
         }
     }

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/quiz/QuizScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/quiz/QuizScreenTest.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.quiz
 
+import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -32,7 +33,7 @@ class QuizScreenTest {
     fun setUp() {
         hiltRule.inject()
 
-        composeRule.setContent {
+        composeRule.activity.setContent {
             QuizScreen()
         }
     }

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/SettingTopScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/SettingTopScreenTest.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.setting
 
+import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -45,7 +46,7 @@ class SettingTopScreenTest {
         val navigation = listOf(
             SettingNavigation.ClearCache
         )
-        composeRule.setContent {
+        composeRule.activity.setContent {
             SettingTopScreen(
                 navController = navController,
                 navigationList = navigation,

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/SettingTopScreenVersionTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/SettingTopScreenVersionTest.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.setting
 
+import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -42,7 +43,7 @@ class SettingTopScreenVersionTest {
         hiltRule.inject()
         MockKAnnotations.init(this)
 
-        composeRule.setContent {
+        composeRule.activity.setContent {
             VersionInfo {
             }
         }

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/CacheClearDialogTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/CacheClearDialogTest.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.setting.pages
 
+import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -44,7 +45,7 @@ class CacheClearDialogTest {
         hiltRule.inject()
         MockKAnnotations.init(this)
 
-        composeRule.setContent {
+        composeRule.activity.setContent {
             CacheClearDialog(
                 navController = navController,
                 uiState = uiState,

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/ReportIssueScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/ReportIssueScreenTest.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.setting.pages
 
+import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -45,7 +46,7 @@ class ReportIssueScreenTest {
         hiltRule.inject()
         MockKAnnotations.init(this)
 
-        composeRule.setContent {
+        composeRule.activity.setContent {
             ReportIssueScreen(
                 viewModel = viewModel,
                 uiState = uiState,

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/SetThemeScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/SetThemeScreenTest.kt
@@ -1,6 +1,7 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.setting.pages
 
 import android.content.Context
+import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.*
@@ -45,7 +46,7 @@ class SetThemeScreenTest {
         hiltRule.inject()
         MockKAnnotations.init(this)
 
-        composeRule.setContent {
+        composeRule.activity.setContent {
             context = LocalContext.current
             SetThemeScreen(
                 navController = navController,

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/SetThemeScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/SetThemeScreenTest.kt
@@ -1,16 +1,13 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.setting.pages
 
-import android.content.Context
 import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.navigation.NavHostController
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
-import jp.mydns.kokoichi0206.sakamichiapp.R
 import jp.mydns.kokoichi0206.sakamichiapp.di.AppModule
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.MainActivity
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.setting.SettingsViewModel
@@ -39,15 +36,12 @@ class SetThemeScreenTest {
     @RelaxedMockK
     lateinit var viewModel: SettingsViewModel
 
-    lateinit var context: Context
-
     @Before
     fun setUp() {
         hiltRule.inject()
         MockKAnnotations.init(this)
 
         composeRule.activity.setContent {
-            context = LocalContext.current
             SetThemeScreen(
                 navController = navController,
                 viewModel = viewModel,
@@ -58,8 +52,7 @@ class SetThemeScreenTest {
     @Test
     fun setThemeScreen_display() {
         // Arrange
-        val expectedStr =
-            context.resources.getString(R.string.set_theme_title)
+        val expectedStr = "テーマカラー"
 
         // Act
 
@@ -131,7 +124,6 @@ class SetThemeScreenTest {
         val theme = ThemeType.Sakurazaka
         verify(exactly = 0) {
             viewModel.setThemeType(theme)
-            viewModel.writeTheme(context, theme.name)
         }
 
         // Act
@@ -142,7 +134,6 @@ class SetThemeScreenTest {
         // Assert
         verify(exactly = 1) {
             viewModel.setThemeType(theme)
-            viewModel.writeTheme(context, theme.name)
         }
     }
 }

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/ShareAppScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/ShareAppScreenTest.kt
@@ -1,9 +1,7 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.setting.pages
 
-import android.content.Context
 import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -12,7 +10,6 @@ import androidx.navigation.NavHostController
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
-import jp.mydns.kokoichi0206.sakamichiapp.R
 import jp.mydns.kokoichi0206.sakamichiapp.di.AppModule
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.MainActivity
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.setting.SettingsUiState
@@ -40,15 +37,12 @@ class ShareAppScreenTest {
     @RelaxedMockK
     lateinit var uiState: SettingsUiState
 
-    lateinit var context: Context
-
     @Before
     fun setUp() {
         hiltRule.inject()
         MockKAnnotations.init(this)
 
         composeRule.activity.setContent {
-            context = LocalContext.current
             ShareAppScreen(
                 navController = navController,
                 uiState = uiState,
@@ -59,10 +53,8 @@ class ShareAppScreenTest {
     @Test
     fun shareAppScreen_display() {
         // Arrange
-        val expectedTitleStr =
-            context.resources.getString(R.string.share_app_title)
-        val expectedMessageStr =
-            context.resources.getString(R.string.share_app_message)
+        val expectedTitleStr = "アプリをシェアする"
+        val expectedMessageStr = "他のアプリを開く"
 
         // Act
 

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/ShareAppScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/ShareAppScreenTest.kt
@@ -1,6 +1,7 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.setting.pages
 
 import android.content.Context
+import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertTextEquals
@@ -46,7 +47,7 @@ class ShareAppScreenTest {
         hiltRule.inject()
         MockKAnnotations.init(this)
 
-        composeRule.setContent {
+        composeRule.activity.setContent {
             context = LocalContext.current
             ShareAppScreen(
                 navController = navController,

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/UpdateBlogScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/UpdateBlogScreenTest.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.setting.pages
 
+import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -45,7 +46,7 @@ class UpdateBlogScreenTest {
         hiltRule.inject()
         MockKAnnotations.init(this)
 
-        composeRule.setContent {
+        composeRule.activity.setContent {
             UpdateBlogScreen(
                 navController = navController,
                 viewModel = viewModel,

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/util/BottomNavigationBarTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/util/BottomNavigationBarTest.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.util
 
+import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.Modifier
@@ -42,7 +43,7 @@ class BottomNavigationBarTest {
         hiltRule.inject()
         MockKAnnotations.init(this)
 
-        composeRule.setContent {
+        composeRule.activity.setContent {
             BottomNavigationBar(
                 modifier = Modifier.height(56.dp),
                 navController = navController,

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/data/remote/LoggingInterceptor.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/data/remote/LoggingInterceptor.kt
@@ -1,0 +1,29 @@
+package jp.mydns.kokoichi0206.sakamichiapp.data.remote
+
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import timber.log.Timber
+import java.io.IOException
+
+/**
+ * Logger for HTTP request.
+ */
+internal class LoggingInterceptor : Interceptor {
+
+    private val tag = "LoggingInterceptor"
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request: Request = chain.request()
+        val t1 = System.nanoTime()
+        Timber.tag(tag).d("${request.url}, ${request.url}")
+
+        val response: Response = chain.proceed(request)
+        val t2 = System.nanoTime()
+        Timber.tag(tag).d("${response.request.url}, ${(t2 - t1) / 1e6}, ${response.headers}")
+        Timber.tag(tag).d("${(t2 - t1) / 1e6} m sec")
+
+        return response
+    }
+}

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/data/remote/RetryInterceptor.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/data/remote/RetryInterceptor.kt
@@ -1,0 +1,28 @@
+package jp.mydns.kokoichi0206.sakamichiapp.data.remote
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Retry HTTP request.
+ */
+class RetryInterceptor : Interceptor {
+
+    companion object {
+        private const val MAX_RETRY_COUNT = 3
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        var response = chain.proceed(request)
+
+        var counts = 0
+        while (!response.isSuccessful && counts < MAX_RETRY_COUNT) {
+            counts++
+
+            response.close()
+            response = chain.proceed(request)
+        }
+        return response
+    }
+}

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/di/AppModule.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/di/AppModule.kt
@@ -11,11 +11,14 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import jp.mydns.kokoichi0206.sakamichiapp.data.local.QuizRecordDatabase
+import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
 import jp.mydns.kokoichi0206.sakamichiapp.data.repository.QuizRecordRepositoryImpl
 import jp.mydns.kokoichi0206.sakamichiapp.domain.repository.QuizRecordRepository
 import jp.mydns.kokoichi0206.sakamichiapp.domain.usecase.quiz_record.*
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 /**
@@ -29,8 +32,14 @@ object AppModule {
     @Provides
     @Singleton
     fun provideSakamichiApi(): SakamichiApi {
+        val okHttpClient = OkHttpClient.Builder()
+            // サーバー側の設定か、なぜか指定が必要！
+            .connectTimeout(777, TimeUnit.MILLISECONDS)
+            .addInterceptor(LoggingInterceptor())
+            .build()
         return Retrofit.Builder()
             .baseUrl(Constants.BASE_URL)
+            .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
             .create(SakamichiApi::class.java)

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/di/AppModule.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/di/AppModule.kt
@@ -12,6 +12,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import jp.mydns.kokoichi0206.sakamichiapp.data.local.QuizRecordDatabase
 import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
+import jp.mydns.kokoichi0206.sakamichiapp.data.remote.RetryInterceptor
 import jp.mydns.kokoichi0206.sakamichiapp.data.repository.QuizRecordRepositoryImpl
 import jp.mydns.kokoichi0206.sakamichiapp.domain.repository.QuizRecordRepository
 import jp.mydns.kokoichi0206.sakamichiapp.domain.usecase.quiz_record.*
@@ -36,6 +37,7 @@ object AppModule {
             // サーバー側の設定か、なぜか指定が必要！
             .connectTimeout(777, TimeUnit.MILLISECONDS)
             .addInterceptor(LoggingInterceptor())
+            .addInterceptor(RetryInterceptor())
             .build()
         return Retrofit.Builder()
             .baseUrl(Constants.BASE_URL)

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogScreen.kt
@@ -40,6 +40,7 @@ import jp.mydns.kokoichi0206.sakamichiapp.presentation.util.TestTags
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.util.getBlogUrlProps
 import jp.mydns.kokoichi0206.sakamichiapp.R
 import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.blog.components.SkeletonBlogScreen
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list.GroupName
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
@@ -87,16 +88,25 @@ fun BlogScreen(
             },
         )
 
-        val rows = uiState.blogs.chunked(Constants.BLOG_ONE_ROW_NUM)
-        LazyColumn(
-            contentPadding = Constants.BottomBarPadding,
-        ) {
-            items(rows) { row ->
-                OneBlogRow(
-                    row = row,
-                    uiState = uiState,
-                    navController = navController,
-                )
+        if (uiState.isLoading) {
+            SkeletonBlogScreen()
+        } else if (uiState.error.isNotBlank()) {
+            Text(
+                text = uiState.error,
+                color = MaterialTheme.colors.primary,
+            )
+        } else {
+            val rows = uiState.blogs.chunked(Constants.BLOG_ONE_ROW_NUM)
+            LazyColumn(
+                contentPadding = Constants.BottomBarPadding,
+            ) {
+                items(rows) { row ->
+                    OneBlogRow(
+                        row = row,
+                        uiState = uiState,
+                        navController = navController,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogScreen.kt
@@ -41,6 +41,7 @@ import jp.mydns.kokoichi0206.sakamichiapp.presentation.util.getBlogUrlProps
 import jp.mydns.kokoichi0206.sakamichiapp.R
 import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.blog.components.SkeletonBlogScreen
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.blog.components.blogImage
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list.GroupName
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
@@ -281,9 +282,7 @@ fun OneBlog(
             contentScale = ContentScale.Crop,
             alignment = Alignment.Center,
             modifier = Modifier
-                .size(120.dp)
-                .padding(2.dp)
-                .clip(MaterialTheme.shapes.medium),
+                .blogImage(),
         )
 
         Text(

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -25,16 +26,23 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import coil.compose.rememberImagePainter
+import coil.ImageLoader
+import coil.compose.AsyncImage
+import coil.disk.DiskCache
+import coil.memory.MemoryCache
+import coil.request.ImageRequest
 import jp.mydns.kokoichi0206.sakamichiapp.domain.model.Blog
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list.GroupBar
-import jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list.GroupName
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.ui.theme.*
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.util.Constants
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.util.Screen
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.util.TestTags
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.util.getBlogUrlProps
 import jp.mydns.kokoichi0206.sakamichiapp.R
+import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list.GroupName
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
 
 @Composable
 fun BlogScreenWithCustomTheme(
@@ -218,28 +226,56 @@ fun OneBlog(
             .testTag(TestTags.BLOG_ONE_BOX),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Image(
-            painter = rememberImagePainter(blog.lastBlogImg,
-                builder = {
-                    placeholder(
-                        when (uiState.groupName) {
-                            GroupName.NOGIZAKA ->
-                                R.drawable.nogizaka_official_icon
-                            GroupName.SAKURAZAKA ->
-                                R.drawable.sakurazaka_official_icon
-                            GroupName.HINATAZAKA ->
-                                R.drawable.hinata_official_icon
-                        }
-                    )
-                }),
+        val context = LocalContext.current
+
+        val request = ImageRequest.Builder(context)
+            .data(blog.lastBlogImg)
+            .placeholder(
+                when (uiState.groupName) {
+                    GroupName.NOGIZAKA ->
+                        R.drawable.nogizaka_official_icon
+                    GroupName.SAKURAZAKA ->
+                        R.drawable.sakurazaka_official_icon
+                    GroupName.HINATAZAKA ->
+                        R.drawable.hinata_official_icon
+                }
+            )
+            .build()
+        val imageLoader = ImageLoader.Builder(context)
+            .crossfade(true)
+            .okHttpClient {
+                OkHttpClient.Builder()
+                    .addInterceptor(LoggingInterceptor())
+                    // サーバー側の設定か、なぜか指定が必要！
+                    .connectTimeout(777, TimeUnit.MILLISECONDS)
+                    .build()
+            }
+            .memoryCache {
+                MemoryCache.Builder(context)
+                    .maxSizePercent(0.25)
+                    .strongReferencesEnabled(true)
+                    .build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(context.cacheDir.resolve("image_cache"))
+                    .maxSizePercent(0.02)
+                    .build()
+            }
+            .build()
+
+        AsyncImage(
+            model = request,
+            imageLoader = imageLoader,
             contentDescription = "blog image of ${blog.name}",
             contentScale = ContentScale.Crop,
+            alignment = Alignment.Center,
             modifier = Modifier
                 .size(120.dp)
                 .padding(2.dp)
                 .clip(MaterialTheme.shapes.medium),
-            alignment = Alignment.Center,
         )
+
         Text(
             modifier = Modifier
                 .padding(SpaceSmall),

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogScreen.kt
@@ -40,6 +40,7 @@ import jp.mydns.kokoichi0206.sakamichiapp.presentation.util.TestTags
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.util.getBlogUrlProps
 import jp.mydns.kokoichi0206.sakamichiapp.R
 import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
+import jp.mydns.kokoichi0206.sakamichiapp.data.remote.RetryInterceptor
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.blog.components.SkeletonBlogScreen
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.blog.components.blogImage
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list.GroupName
@@ -257,6 +258,7 @@ fun OneBlog(
             .okHttpClient {
                 OkHttpClient.Builder()
                     .addInterceptor(LoggingInterceptor())
+                    .addInterceptor(RetryInterceptor())
                     // サーバー側の設定か、なぜか指定が必要！
                     .connectTimeout(777, TimeUnit.MILLISECONDS)
                     .build()

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogUiState.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogUiState.kt
@@ -8,6 +8,8 @@ import jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list.GroupName
  */
 data class BlogUiState(
     var loaded: Boolean = false,
+    var isLoading: Boolean = false,
+    var error: String = "",
     var groupName: GroupName = GroupName.NOGIZAKA,
     var blogs: List<Blog> = emptyList(),
     // Sort blogs by lastUpdatedTime or memberName.

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogViewModel.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogViewModel.kt
@@ -77,6 +77,7 @@ open class BlogViewModel @Inject constructor(
     }
 
     fun setApiBlogs() {
+        setBlogs(mutableListOf())
         getBlogs(uiState.value.groupName)
     }
 

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogViewModel.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogViewModel.kt
@@ -1,7 +1,5 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.blog
 
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,10 +17,6 @@ import javax.inject.Inject
 open class BlogViewModel @Inject constructor(
     private val getBlogsUseCase: GetBlogsUseCase
 ) : ViewModel() {
-
-    private val _apiState = mutableStateOf(BlogApiState())
-    var apiState: State<BlogApiState> = _apiState
-
     private val _uiState = MutableStateFlow(BlogUiState())
     var uiState: StateFlow<BlogUiState> = _uiState
 
@@ -32,25 +26,26 @@ open class BlogViewModel @Inject constructor(
      * @param groupName group name (one of the GroupName enum)
      */
     private fun getBlogs(groupName: GroupName) {
+        _uiState.update { it.copy(isLoading = true) }
         getBlogsUseCase(groupName.name.lowercase()).onEach { result ->
             when (result) {
                 is Resource.Success -> {
-                    _apiState.value =
-                        BlogApiState(
-                            members = result.data!!
-                                .toMutableList()
-                        )
-                    setBlogs(_apiState.value.members)
+                    setBlogs(result.data!!.toMutableList())
+                    _uiState.update { it.copy(isLoading = false) }
+
                     // Sorting here is the best??
                     sortBlogs()
                 }
                 is Resource.Error -> {
-                    _apiState.value = BlogApiState(
-                        error = result.message ?: "An unexpected error occurred."
-                    )
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = result.message ?: "An unexpected error occurred."
+                        )
+                    }
                 }
                 is Resource.Loading -> {
-                    _apiState.value = BlogApiState(isLoading = true)
+                    _uiState.update { it.copy(isLoading = true) }
                 }
             }
         }.launchIn(viewModelScope)

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/components/CustomModifier.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/components/CustomModifier.kt
@@ -1,0 +1,16 @@
+package jp.mydns.kokoichi0206.sakamichiapp.presentation.blog.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+
+fun Modifier.blogImage(): Modifier =
+    composed {
+        size(120.dp)
+            .padding(2.dp)
+            .clip(MaterialTheme.shapes.medium)
+    }

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/components/SkeletonBlogScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/components/SkeletonBlogScreen.kt
@@ -1,0 +1,108 @@
+package jp.mydns.kokoichi0206.sakamichiapp.presentation.blog.components
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Skeleton Screen
+ * ref: https://mui.com/material-ui/react-skeleton/#variants
+ */
+@Composable
+fun SkeletonBlogScreen() {
+    LazyColumn {
+        items(8) {
+            Row {
+                Box(modifier = Modifier.weight(1f))
+                SkeletonPart(120.dp)
+                Box(modifier = Modifier.weight(1f))
+                SkeletonPart(120.dp)
+                Box(modifier = Modifier.weight(1f))
+                SkeletonPart(120.dp)
+                Box(modifier = Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+fun SkeletonPart(
+    size: Dp,
+) {
+    val gradient = listOf(
+        Color.LightGray.copy(alpha = 0.9f),
+        Color.LightGray.copy(alpha = 0.3f),
+        Color.LightGray.copy(alpha = 0.9f)
+    )
+
+    val transition = rememberInfiniteTransition()
+
+    val translateAnimation = transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = 1000,
+                easing = FastOutLinearInEasing
+            )
+        )
+    )
+    val brush = linearGradient(
+        colors = gradient,
+        start = Offset(200f, 200f),
+        end = Offset(
+            x = translateAnimation.value,
+            y = translateAnimation.value
+        )
+    )
+    Column(
+        modifier = Modifier
+            .padding(vertical = 8.dp)
+            .width(size)
+    ) {
+        Spacer(
+            modifier = Modifier
+                .size(120.dp)
+                .padding(2.dp)
+                .clip(MaterialTheme.shapes.medium)
+                .background(brush)
+        )
+        Spacer(
+            modifier = Modifier
+                .height(8.dp)
+        )
+        Spacer(
+            modifier = Modifier
+                .height(20.dp)
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(10.dp))
+                .background(brush)
+        )
+        Spacer(
+            modifier = Modifier
+                .height(12.dp)
+        )
+        Spacer(
+            modifier = Modifier
+                .height(20.dp)
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(10.dp))
+                .background(brush)
+        )
+        Spacer(
+            modifier = Modifier
+                .height(12.dp)
+        )
+    }
+}

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/components/SkeletonBlogScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/components/SkeletonBlogScreen.kt
@@ -5,8 +5,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
@@ -14,6 +15,10 @@ import androidx.compose.ui.graphics.Brush.Companion.linearGradient
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.ui.theme.SpaceSmall
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.ui.theme.SpaceTiny
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.ui.theme.Typography
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.util.Constants
 
 /**
  * Skeleton Screen
@@ -21,7 +26,9 @@ import androidx.compose.ui.unit.dp
  */
 @Composable
 fun SkeletonBlogScreen() {
-    LazyColumn {
+    LazyColumn(
+        contentPadding = Constants.BottomBarPadding,
+    ) {
         items(8) {
             Row {
                 Box(modifier = Modifier.weight(1f))
@@ -68,41 +75,36 @@ fun SkeletonPart(
     )
     Column(
         modifier = Modifier
-            .padding(vertical = 8.dp)
-            .width(size)
+            .padding(vertical = SpaceSmall)
+            .width(size),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Spacer(
             modifier = Modifier
-                .size(120.dp)
-                .padding(2.dp)
-                .clip(MaterialTheme.shapes.medium)
-                .background(brush)
+                .blogImage()
+                .background(brush),
         )
-        Spacer(
+
+        Text(
             modifier = Modifier
-                .height(8.dp)
-        )
-        Spacer(
-            modifier = Modifier
-                .height(20.dp)
+                .padding(top = SpaceSmall)
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(10.dp))
-                .background(brush)
+                .clip(RoundedCornerShape(5.dp))
+                .background(brush),
+            text = "name",
+            style = Typography.body2,
+            color = Color.Transparent,
         )
-        Spacer(
+        Text(
             modifier = Modifier
-                .height(12.dp)
-        )
-        Spacer(
-            modifier = Modifier
-                .height(20.dp)
+                .padding(top = SpaceSmall)
+                .padding(bottom = SpaceTiny)
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(10.dp))
-                .background(brush)
-        )
-        Spacer(
-            modifier = Modifier
-                .height(12.dp)
+                .clip(RoundedCornerShape(5.dp))
+                .background(brush),
+            text = "time",
+            style = Typography.caption,
+            color = Color.Transparent,
         )
     }
 }

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_detail/MemberImage.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_detail/MemberImage.kt
@@ -1,16 +1,24 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.member_detail
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberImagePainter
+import coil.ImageLoader
+import coil.compose.AsyncImage
+import coil.disk.DiskCache
+import coil.memory.MemoryCache
+import coil.request.ImageRequest
 import jp.mydns.kokoichi0206.sakamichiapp.R
+import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
 
 /**
  * Member Image
@@ -24,30 +32,51 @@ fun MemberImage(
             .fillMaxWidth()
             .padding(vertical = 20.dp, horizontal = 60.dp)
     ) {
-        Image(
-            painter = rememberImagePainter(uiState.member?.imgUrl,
-                builder = {
-                    placeholder(
-                        when (uiState.member?.group) {
-                            "乃木坂" ->
-                                R.drawable.nogizaka_official_icon
-                            "櫻坂" ->
-                                R.drawable.sakurazaka_official_icon
-                            else ->
-                                R.drawable.hinata_official_icon
-                        }
-                    )
-                    listener(
-                        onStart = {
-                            // set your progressbar visible here
-                        },
-                        onSuccess = { request, metadata ->
-                            // set your progressbar invisible here
-                        }
-                    )
-                }),
-            contentDescription = "image of ${uiState.member!!.name}",
-            contentScale = ContentScale.Crop, // crop the image if it's not a square
+        val member = uiState.member
+        val context = LocalContext.current
+
+        val request = ImageRequest.Builder(context)
+            .data(member?.imgUrl)
+            .placeholder(
+                when (member?.group) {
+                    "乃木坂" ->
+                        R.drawable.nogizaka_official_icon
+                    "櫻坂" ->
+                        R.drawable.sakurazaka_official_icon
+                    else ->
+                        R.drawable.hinata_official_icon
+                }
+            )
+            .build()
+        val imageLoader = ImageLoader.Builder(context)
+            .crossfade(true)
+            .okHttpClient {
+                OkHttpClient.Builder()
+                    .addInterceptor(LoggingInterceptor())
+                    // サーバー側の設定か、なぜか指定が必要！
+                    .connectTimeout(777, TimeUnit.MILLISECONDS)
+                    .build()
+            }
+            .memoryCache {
+                MemoryCache.Builder(context)
+                    .maxSizePercent(0.25)
+                    .strongReferencesEnabled(true)
+                    .build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(context.cacheDir.resolve("image_cache"))
+                    .maxSizePercent(0.02)
+                    .build()
+            }
+            .build()
+
+        AsyncImage(
+            model = request,
+            imageLoader = imageLoader,
+            contentDescription = "",
+            contentScale = ContentScale.Crop,
+            alignment = Alignment.TopStart,
             modifier = Modifier
                 .size(350.dp),
         )

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MainColumn.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MainColumn.kt
@@ -1,6 +1,5 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.MaterialTheme
@@ -46,10 +45,6 @@ fun DefaultColumn(
     members: MutableList<Member> = uiState.visibleMembers,
 ) {
     LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colors.background)
-            .padding(horizontal = SpaceMedium),
         contentPadding = Constants.BottomBarPadding,
     ) {
         val itemCount = if (members.size % 3 == 0) {
@@ -102,10 +97,6 @@ fun ColumnWithLine(
             getGenerationLooper(uiState.groupName.jname)
     }
     LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colors.background)
-            .padding(horizontal = SpaceMedium),
         contentPadding = Constants.BottomBarPadding,
     ) {
         for (type in looperStr) {

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListScreen.kt
@@ -1,18 +1,23 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list.components.SortBar
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.ui.theme.CustomSakaTheme
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.ui.theme.SpaceMedium
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.ui.theme.SpaceSmall
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list.components.SkeletonMemberScreen
 
 /**
  * Function to display member list.
@@ -29,7 +34,6 @@ fun MemberListScreen(
     }
 
     val uiState by viewModel.uiState.collectAsState()
-
     CustomSakaTheme(group = uiState.groupName.jname) {
         MainView(
             uiState, navController, viewModel
@@ -61,9 +65,27 @@ fun MainView(
             viewModel = viewModel,
         )
 
-        MainColumn(
-            uiState = uiState,
-            navController = navController,
-        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colors.background)
+                .padding(horizontal = SpaceMedium),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (uiState.isLoading) {
+                // スケルトンスクリーン。
+                SkeletonMemberScreen()
+            } else if (uiState.error.isNotBlank()) {
+                Text(
+                    text = uiState.error,
+                    color = MaterialTheme.colors.primary,
+                )
+            } else {
+                MainColumn(
+                    uiState = uiState,
+                    navController = navController,
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListUiState.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListUiState.kt
@@ -8,6 +8,8 @@ import jp.mydns.kokoichi0206.sakamichiapp.domain.model.Member
 data class MemberListUiState(
     var favorites: Set<String> = emptySet(),
     var loaded: Boolean = false,
+    var isLoading: Boolean = false,
+    var error: String = "",
     var groupName: GroupName = GroupName.NOGIZAKA,
     var visibleStyle: VisibleMemberStyle = VisibleMemberStyle.DEFAULT,
     var sortKey: MemberListSortKeys = MemberListSortKeys.NONE,
@@ -38,7 +40,7 @@ enum class VisibleMemberStyle {
 /**
  * Keys to sort members.
  */
-enum class MemberListSortKeys(val jname: String){
+enum class MemberListSortKeys(val jname: String) {
     NONE("なし"),     // No sort (default).
     NAME("名前"),
     GENERATION("期別"),

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListViewModel.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListViewModel.kt
@@ -100,6 +100,7 @@ open class MemberListViewModel @Inject constructor(
             MemberListSortKeys.HEIGHT -> {
                 _uiState.value.visibleMembers.sortBy { it.height }
             }
+            else -> {}
         }
     }
 
@@ -128,6 +129,7 @@ open class MemberListViewModel @Inject constructor(
             MemberListSortKeys.HEIGHT -> {
                 _uiState.value.visibleMembers.sortByDescending { it.height }
             }
+            else -> {}
         }
     }
 

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListViewModel.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListViewModel.kt
@@ -175,6 +175,7 @@ open class MemberListViewModel @Inject constructor(
      * Reset the members (in apiState) using groupName (in uiState).
      */
     fun setApiMembers() {
+        setVisibleMembers(mutableListOf())
         getMembers(uiState.value.groupName)
 
         // TODO: Consider what logic is the best.

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListViewModel.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListViewModel.kt
@@ -35,6 +35,7 @@ open class MemberListViewModel @Inject constructor(
      * @param groupName group name (one of the GroupName enum)
      */
     fun getMembers(groupName: GroupName) {
+        _uiState.update { it.copy(isLoading = true, error = "") }
         getMembersUseCase(groupName.name.lowercase()).onEach { result ->
             when (result) {
                 is Resource.Success -> {
@@ -46,12 +47,16 @@ open class MemberListViewModel @Inject constructor(
                                     it.group = groupName.jname
                                 }
                         )
+                    _uiState.update { it.copy(isLoading = false) }
                     setVisibleMembers(_apiState.value.members)
                 }
                 is Resource.Error -> {
                     _apiState.value = MemberListApiState(
                         error = result.message ?: "An unexpected error occurred."
                     )
+                    _uiState.update {
+                        it.copy(isLoading = false, error = result.message ?: "An unexpected error occurred.")
+                    }
                 }
                 is Resource.Loading -> {
                     _apiState.value = MemberListApiState(isLoading = true)

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/components/CustomModifier.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/components/CustomModifier.kt
@@ -1,0 +1,18 @@
+package jp.mydns.kokoichi0206.sakamichiapp.presentation.member_detail.components
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+
+fun Modifier.memberImage(): Modifier =
+    composed {
+        size(110.dp)
+            .clip(CircleShape)
+            .border(2.dp, MaterialTheme.colors.secondary, CircleShape)
+    }

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/components/OnePerson.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/components/OnePerson.kt
@@ -1,16 +1,12 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list.components
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -25,6 +21,7 @@ import coil.request.ImageRequest
 import jp.mydns.kokoichi0206.sakamichiapp.R
 import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
 import jp.mydns.kokoichi0206.sakamichiapp.domain.model.Member
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.member_detail.components.memberImage
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 
@@ -93,9 +90,7 @@ fun OnePerson(
                     .clickable {
                         onclick(member)
                     }
-                    .size(110.dp)
-                    .clip(CircleShape)
-                    .border(2.dp, MaterialTheme.colors.secondary, CircleShape),
+                    .memberImage(),
             )
 
             Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/components/OnePerson.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/components/OnePerson.kt
@@ -20,6 +20,7 @@ import coil.memory.MemoryCache
 import coil.request.ImageRequest
 import jp.mydns.kokoichi0206.sakamichiapp.R
 import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
+import jp.mydns.kokoichi0206.sakamichiapp.data.remote.RetryInterceptor
 import jp.mydns.kokoichi0206.sakamichiapp.domain.model.Member
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.member_detail.components.memberImage
 import okhttp3.OkHttpClient
@@ -62,6 +63,7 @@ fun OnePerson(
                 .okHttpClient {
                     OkHttpClient.Builder()
                         .addInterceptor(LoggingInterceptor())
+                        .addInterceptor(RetryInterceptor())
                         // サーバー側の設定か、なぜか指定が必要！
                         .connectTimeout(777, TimeUnit.MILLISECONDS)
                         .build()

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/components/OnePerson.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/components/OnePerson.kt
@@ -85,7 +85,7 @@ fun OnePerson(
             AsyncImage(
                 model = request,
                 imageLoader = imageLoader,
-                contentDescription = "",
+                contentDescription = "image of ${member.name}",
                 contentScale = ContentScale.Crop,
                 alignment = Alignment.TopStart,
                 modifier = Modifier

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/components/SkeletonMemberScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/components/SkeletonMemberScreen.kt
@@ -4,16 +4,21 @@ import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush.Companion.linearGradient
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.member_detail.components.memberImage
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.ui.theme.SpaceMedium
+import jp.mydns.kokoichi0206.sakamichiapp.presentation.util.Constants
 
 /**
  * Skeleton Screen
@@ -21,23 +26,23 @@ import androidx.compose.ui.unit.dp
  */
 @Composable
 fun SkeletonMemberScreen() {
-    LazyColumn {
+    LazyColumn(
+        contentPadding = Constants.BottomBarPadding,
+    ) {
         items(8) {
             Row {
-                SkeletonPart(110.dp)
-                Box(modifier = Modifier.weight(1f))
-                SkeletonPart(110.dp)
-                Box(modifier = Modifier.weight(1f))
-                SkeletonPart(110.dp)
+                SkeletonPart()
+                Spacer(modifier = Modifier.width(SpaceMedium))
+                SkeletonPart()
+                Spacer(modifier = Modifier.width(SpaceMedium))
+                SkeletonPart()
             }
         }
     }
 }
 
 @Composable
-fun SkeletonPart(
-    size: Dp,
-) {
+fun SkeletonPart() {
     val gradient = listOf(
         Color.LightGray.copy(alpha = 0.9f),
         Color.LightGray.copy(alpha = 0.3f),
@@ -66,28 +71,26 @@ fun SkeletonPart(
     )
     Column(
         modifier = Modifier
-            .width(size)
+            .width(110.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Spacer(
             modifier = Modifier
-                .size(size)
-                .clip(CircleShape)
+                .memberImage()
                 .background(brush)
         )
-        Spacer(
+
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
             modifier = Modifier
-                .height(8.dp)
-        )
-        Spacer(
-            modifier = Modifier
-                .height(24.dp)
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(10.dp))
-                .background(brush)
+                .clip(RoundedCornerShape(5.dp))
+                .background(brush),
+            text = "name",
+            color = Color.Transparent,
+            fontSize = 14.sp,
+            textAlign = TextAlign.Center,
         )
-        Spacer(
-            modifier = Modifier
-                .height(24.dp)
-        )
+        Spacer(modifier = Modifier.height(12.dp))
     }
 }

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/components/SkeletonMemberScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/components/SkeletonMemberScreen.kt
@@ -1,0 +1,93 @@
+package jp.mydns.kokoichi0206.sakamichiapp.presentation.member_list.components
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Skeleton Screen
+ * ref: https://mui.com/material-ui/react-skeleton/#variants
+ */
+@Composable
+fun SkeletonMemberScreen() {
+    LazyColumn {
+        items(8) {
+            Row {
+                SkeletonPart(110.dp)
+                Box(modifier = Modifier.weight(1f))
+                SkeletonPart(110.dp)
+                Box(modifier = Modifier.weight(1f))
+                SkeletonPart(110.dp)
+            }
+        }
+    }
+}
+
+@Composable
+fun SkeletonPart(
+    size: Dp,
+) {
+    val gradient = listOf(
+        Color.LightGray.copy(alpha = 0.9f),
+        Color.LightGray.copy(alpha = 0.3f),
+        Color.LightGray.copy(alpha = 0.9f)
+    )
+
+    val transition = rememberInfiniteTransition()
+
+    val translateAnimation = transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = 1000,
+                easing = FastOutLinearInEasing
+            )
+        )
+    )
+    val brush = linearGradient(
+        colors = gradient,
+        start = Offset(200f, 200f),
+        end = Offset(
+            x = translateAnimation.value,
+            y = translateAnimation.value
+        )
+    )
+    Column(
+        modifier = Modifier
+            .width(size)
+    ) {
+        Spacer(
+            modifier = Modifier
+                .size(size)
+                .clip(CircleShape)
+                .background(brush)
+        )
+        Spacer(
+            modifier = Modifier
+                .height(8.dp)
+        )
+        Spacer(
+            modifier = Modifier
+                .height(24.dp)
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(10.dp))
+                .background(brush)
+        )
+        Spacer(
+            modifier = Modifier
+                .height(24.dp)
+        )
+    }
+}

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/positions/PositionsScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/positions/PositionsScreen.kt
@@ -1,24 +1,31 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.positions
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.rememberImagePainter
+import coil.ImageLoader
+import coil.compose.AsyncImage
+import coil.disk.DiskCache
+import coil.memory.MemoryCache
+import coil.request.ImageRequest
 import jp.mydns.kokoichi0206.sakamichiapp.R
+import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
 import jp.mydns.kokoichi0206.sakamichiapp.domain.model.Position
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
 
 @Composable
 fun PositionsScreen(
@@ -90,56 +97,51 @@ fun EachRow(positions: List<Position>) {
                 modifier = Modifier.padding(IMG_PADDING)
             ) {
 
-                var loadError by remember { mutableStateOf(false) }
+                val context = LocalContext.current
 
-                val painter = rememberImagePainter(position.imgUrl,
-                    builder = {
-                        placeholder(R.drawable.hinata_official_icon)
-                        listener(
-                            onStart = {
-                            },
-                            onSuccess = { request, metadata ->
-                            },
-                            onError = { req, thro ->
-                                loadError = true
-                            }
-                        )
-                    })
+                val request = ImageRequest.Builder(context)
+                    .data(position.imgUrl)
+                    .placeholder(R.drawable.hinata_official_icon)
+                    .build()
+                val imageLoader = ImageLoader.Builder(context)
+                    .crossfade(true)
+                    .okHttpClient {
+                        OkHttpClient.Builder()
+                            .addInterceptor(LoggingInterceptor())
+                            // サーバー側の設定か、なぜか指定が必要！
+                            .connectTimeout(777, TimeUnit.MILLISECONDS)
+                            .build()
+                    }
+                    .memoryCache {
+                        MemoryCache.Builder(context)
+                            .maxSizePercent(0.25)
+                            .strongReferencesEnabled(true)
+                            .build()
+                    }
+                    .diskCache {
+                        DiskCache.Builder()
+                            .directory(context.cacheDir.resolve("image_cache"))
+                            .maxSizePercent(0.02)
+                            .build()
+                    }
+                    .build()
 
-                // In the case where you cannot get a image from the URL
-                if (loadError) {
-                    Image(
-                        painter = painterResource(id = R.drawable.hinata_official_icon),
-                        contentDescription = null,
-                        modifier = Modifier
-                            .size(IMG_SIZE)
-                            .fillMaxWidth()
-                            .clip(CircleShape)
-                            .clickable {
-                                // TODO:
-                                // Error が出てしまった後は、曲名を切り替えてもそこのエラーが残ってしまう
-                                // 一時的な対策として、タップすると再リロサイリロード走るようにする
-                                loadError = false
-                            },
-                        contentScale = ContentScale.Crop
-                    )
-                } else {
-
-                    Image(
-                        painter = painter,
-                        contentDescription = null,
-                        modifier = Modifier
-                            .size(IMG_SIZE)
-                            .fillMaxWidth()
-                            .clip(CircleShape)
-                            .clickable {
-                            },
-                        contentScale = ContentScale.Crop
-                    )
-                }
+                AsyncImage(
+                    model = request,
+                    imageLoader = imageLoader,
+                    contentDescription = null,
+                    alignment = Alignment.Center,
+                    modifier = Modifier
+                        .size(IMG_SIZE)
+                        .fillMaxWidth()
+                        .clip(CircleShape)
+                        .clickable {
+                        },
+                )
 
                 Text(text = position.memberName, fontSize = FONT_SIZE)
             }
         }
     }
 }
+

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/positions/PositionsScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/positions/PositionsScreen.kt
@@ -23,6 +23,7 @@ import coil.memory.MemoryCache
 import coil.request.ImageRequest
 import jp.mydns.kokoichi0206.sakamichiapp.R
 import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
+import jp.mydns.kokoichi0206.sakamichiapp.data.remote.RetryInterceptor
 import jp.mydns.kokoichi0206.sakamichiapp.domain.model.Position
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
@@ -108,6 +109,7 @@ fun EachRow(positions: List<Position>) {
                     .okHttpClient {
                         OkHttpClient.Builder()
                             .addInterceptor(LoggingInterceptor())
+                            .addInterceptor(RetryInterceptor())
                             // サーバー側の設定か、なぜか指定が必要！
                             .connectTimeout(777, TimeUnit.MILLISECONDS)
                             .build()

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/positions/PositionsViewModel.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/positions/PositionsViewModel.kt
@@ -71,6 +71,9 @@ open class PositionsViewModel @Inject constructor(
      * @param songName song name
      */
     fun getPositions(songName: String) {
+        // Clear first
+        _positionState.value = PositionListState(positions = mutableListOf())
+
         getPositionsUseCase(songName).onEach { result ->
             when (result) {
                 is Resource.Success -> {

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/quiz/PlayQuizScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/quiz/PlayQuizScreen.kt
@@ -100,6 +100,7 @@ fun PlayQuizScreen(
                             .padding(50.dp)
                             .testTag(TestTags.WRONG_CORRECT_ICON),
                     )
+                else -> {}
             }
         }
     }

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/quiz/PlayQuizScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/quiz/PlayQuizScreen.kt
@@ -1,6 +1,5 @@
 package jp.mydns.kokoichi0206.sakamichiapp.presentation.quiz
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -30,6 +29,7 @@ import coil.memory.MemoryCache
 import coil.request.ImageRequest
 import jp.mydns.kokoichi0206.sakamichiapp.R
 import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
+import jp.mydns.kokoichi0206.sakamichiapp.data.remote.RetryInterceptor
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.ui.theme.SpaceMedium
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.ui.theme.SpaceSmall
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.ui.theme.Typography
@@ -159,6 +159,7 @@ fun OneQuiz(
                         .okHttpClient {
                             OkHttpClient.Builder()
                                 .addInterceptor(LoggingInterceptor())
+                                .addInterceptor(RetryInterceptor())
                                 // サーバー側の設定か、なぜか指定が必要！
                                 .connectTimeout(777, TimeUnit.MILLISECONDS)
                                 .build()

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/SettingsScreen.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/SettingsScreen.kt
@@ -49,13 +49,13 @@ fun SettingsRouting(
         navController,
         modifier = Modifier.fillMaxSize(),
         startDestination = SettingScreen.SettingTopScreen.route,
-        enterTransition = { _, _ ->
+        enterTransition = {
             slideIntoContainer(
                 AnimatedContentScope.SlideDirection.Left,
                 animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS)
             ) + fadeIn(animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS))
         },
-        popExitTransition = { _, _ ->
+        popExitTransition = {
             slideOutOfContainer(
                 AnimatedContentScope.SlideDirection.Right,
                 animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS)
@@ -73,13 +73,13 @@ fun SettingsRouting(
 
         composable(
             route = SettingScreen.SettingTopScreen.route,
-            exitTransition = { _, _ ->
+            exitTransition = {
                 slideOutOfContainer(
                     AnimatedContentScope.SlideDirection.Left,
                     animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS)
                 ) + fadeOut(animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS))
             },
-            popEnterTransition = { _, _ ->
+            popEnterTransition = {
                 slideIntoContainer(
                     AnimatedContentScope.SlideDirection.Right,
                     animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS)

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/util/BottomNavigation.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/util/BottomNavigation.kt
@@ -177,23 +177,10 @@ fun BottomNavigationBar(
                 unselectedContentColor = unSelectedColor,
                 icon = {
                     Column(horizontalAlignment = CenterHorizontally) {
-                        if (item.badgeCount > 0) {
-                            BadgeBox(
-                                badgeContent = {
-                                    Text(text = item.badgeCount.toString())
-                                }
-                            ) {
-                                Icon(
-                                    painter = painterResource(item.icons),
-                                    contentDescription = item.name,
-                                )
-                            }
-                        } else {
                             Icon(
                                 painter = painterResource(id = item.icons),
                                 contentDescription = item.name
                             )
-                        }
                         Text(
                             text = item.name,
                             textAlign = TextAlign.Center,

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.0.1'
+        compose_version = '1.3.0-rc01'
+        kotlinVersion = "1.7.1"
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
-        classpath "com.google.dagger:hilt-android-gradle-plugin:2.38.1"
+        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10"
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.42'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.6.10")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Sep 23 17:28:45 JST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Issue 番号

#67 

## 対応内容・対応背景

- 表示に時間がかかっており、ユーザーにとってストレスとなっていた問題を解決する
- また、待ち時間が発生した際には、ローディングが進んでいることを示す UI を設計する
  - スケルトンを導入

## やったこと

- Retrofit のコネクションにタイムアウトを設けることで、速度を改善
  - また、タイムアウトを設定したことで取得失敗も多くなったので、リトライ処理を追加
- Skeleton の UI を導入し、ユーザーが待ち時間ストレスにならないように修正
- 速度改善のため、Coil 1 -> 2 にアップデート

## やってないこと
- 

## UI before / after

skeleton の UI
（UI を確認しやすくするよう、通信を遅くしてます）

https://user-images.githubusercontent.com/52474650/197499097-49c8e796-eb43-4dda-8cbd-4c081e74fbc9.mp4


## テスト観点

## 補足
