### PR TITLE
API のローカライズの Android 対応

### DIFF
--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/data/remote/AddHeaderInterceptor.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/data/remote/AddHeaderInterceptor.kt
@@ -1,0 +1,26 @@
+package jp.mydns.kokoichi0206.sakamichiapp.data.remote
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.util.*
+
+/**
+ * Set Header for Retrofit request.
+ */
+class AddHeaderInterceptor : Interceptor {
+
+    companion object {
+        private const val ACCEPT_LANGUAGE_HEADER = "Accept-Language"
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+
+        // Add Accept-Language header according to device language (in settings app).
+        val newReq = request.newBuilder()
+            .header(ACCEPT_LANGUAGE_HEADER, Locale.getDefault().toString())
+            .build()
+
+        return chain.proceed(newReq)
+    }
+}

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/di/AppModule.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/di/AppModule.kt
@@ -11,6 +11,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import jp.mydns.kokoichi0206.sakamichiapp.data.local.QuizRecordDatabase
+import jp.mydns.kokoichi0206.sakamichiapp.data.remote.AddHeaderInterceptor
 import jp.mydns.kokoichi0206.sakamichiapp.data.remote.LoggingInterceptor
 import jp.mydns.kokoichi0206.sakamichiapp.data.remote.RetryInterceptor
 import jp.mydns.kokoichi0206.sakamichiapp.data.repository.QuizRecordRepositoryImpl
@@ -36,6 +37,7 @@ object AppModule {
         val okHttpClient = OkHttpClient.Builder()
             // サーバー側の設定か、なぜか指定が必要！
             .connectTimeout(777, TimeUnit.MILLISECONDS)
+            .addInterceptor(AddHeaderInterceptor())
             .addInterceptor(LoggingInterceptor())
             .addInterceptor(RetryInterceptor())
             .build()

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/util/FunctionUtils.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/util/FunctionUtils.kt
@@ -25,7 +25,9 @@ fun getJsonFromMember(member: Member): String {
             .replace("?", QUESTION_ENCODED),
         imgUrl = member.imgUrl
             .replace("/", SLASH_ENCODED)
-            .replace("?", QUESTION_ENCODED)
+            .replace("?", QUESTION_ENCODED),
+        birthday = member.birthday
+            .replace("/", SLASH_ENCODED),
     )
     return Gson().toJson(props)
 }


### PR DESCRIPTION
## Issue 番号

#76 

## 対応内容・対応背景
- API のローカライズ自体はサーバーで行う
- 対応するのに必要な対応を行う
  - `Accept-Language` ヘッダーを付与

## やったこと
- 

## やってないこと
- 言語が変わったときに、瞬時に変更されない

## UI before / after

<img width="321" alt="Screen Shot 2022-10-31 at 0 34 21" src="https://user-images.githubusercontent.com/52474650/198887392-346f9813-adda-45f6-afe1-cb5662f9e356.png">



## テスト観点

## 補足
