### PR TITLE
Members に対してキャッシュを作成

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
           target: ${{ env.env_target }}
           arch: x86
           profile: Galaxy Nexus
-          script: ./gradlew connectedCheck --stacktrace
+          script: ./gradlew :app:connectedCheck --stacktrace 
 
       # Upload results as a artifact even if the test failed
       - name: Upload Reports

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/AppEndToEnd.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/AppEndToEnd.kt
@@ -12,6 +12,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import jp.mydns.kokoichi0206.data.di.DataModule
 import jp.mydns.kokoichi0206.sakamichiapp.di.AppModule
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.MainActivity
 import jp.mydns.kokoichi0206.settings.SettingNavigation
@@ -30,7 +31,7 @@ import org.junit.Test
 @ExperimentalCoroutinesApi
 @ExperimentalMaterialApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class AppEndToEnd {
 
     @get:Rule(order = 0)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/di/TestAppModule.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/di/TestAppModule.kt
@@ -8,15 +8,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import jp.mydns.kokoichi0206.common.BuildConfigWrapper
 import jp.mydns.kokoichi0206.common.Constants
+import jp.mydns.kokoichi0206.data.local.MembersDatabase
 import jp.mydns.kokoichi0206.data.local.QuizRecordDatabase
-import jp.mydns.kokoichi0206.sakamichiapp.data.remote.MockSakamichiApi
 import jp.mydns.kokoichi0206.data.remote.SakamichiApi
-import jp.mydns.kokoichi0206.data.repository.QuizRecordRepository
-import jp.mydns.kokoichi0206.data.repository.QuizRecordRepositoryImpl
-import jp.mydns.kokoichi0206.data.repository.SakamichiRepository
-import jp.mydns.kokoichi0206.data.repository.SakamichiRepositoryImpl
+import jp.mydns.kokoichi0206.data.repository.*
 import jp.mydns.kokoichi0206.domain.usecase.quiz_record.*
-import jp.mydns.kokoichi0206.sakamichiapp.BuildConfig
+import jp.mydns.kokoichi0206.sakamichiapp.data.remote.MockSakamichiApi
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.mock.MockRetrofit
@@ -71,6 +68,22 @@ object TestAppModule {
     @Singleton
     fun provideQuizRecordRepository(db: QuizRecordDatabase): QuizRecordRepository {
         return QuizRecordRepositoryImpl(db.quizRecordDao)
+    }
+
+    // Database
+    @Provides
+    @Singleton
+    fun provideMembersDatabase(app: Application): MembersDatabase {
+        return Room.inMemoryDatabaseBuilder(
+            app,
+            MembersDatabase::class.java,
+        ).build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideMembersRepository(db: MembersDatabase): MembersRepository {
+        return MembersRepositoryImpl(db.membersDao)
     }
 
     @Provides

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/blog/BlogScreenTest.kt
@@ -16,6 +16,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
 import jp.mydns.kokoichi0206.blog.BlogScreenWithCustomTheme
 import jp.mydns.kokoichi0206.blog.TestTags
+import jp.mydns.kokoichi0206.data.di.DataModule
 import jp.mydns.kokoichi0206.common.TestTags as CommonTestTags
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
@@ -25,7 +26,7 @@ import org.junit.Test
 @ExperimentalMaterialApi
 @ExperimentalCoroutinesApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class BlogScreenTest {
 
     @get:Rule(order = 0)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/member_list/MemberListScreenTest.kt
@@ -13,9 +13,7 @@ import jp.mydns.kokoichi0206.sakamichiapp.presentation.MainActivity
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.verify
-import jp.mydns.kokoichi0206.member_detail.navigation.memberDetailRoute
-import jp.mydns.kokoichi0206.member_detail.navigation.memberJson
-import jp.mydns.kokoichi0206.model.getJsonFromMember
+import jp.mydns.kokoichi0206.data.di.DataModule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
 import org.junit.Rule
@@ -24,7 +22,7 @@ import org.junit.Test
 @ExperimentalMaterialApi
 @ExperimentalCoroutinesApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class MemberListScreenTest {
 
     @get:Rule(order = 0)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/quiz/PlayQuizScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/quiz/PlayQuizScreenTest.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import jp.mydns.kokoichi0206.common.GroupName
+import jp.mydns.kokoichi0206.data.di.DataModule
 import jp.mydns.kokoichi0206.quiz.QuizScreen
 import jp.mydns.kokoichi0206.quiz.QuizType
 import jp.mydns.kokoichi0206.quiz.TestTags
@@ -23,7 +24,7 @@ import org.junit.Test
 @ExperimentalMaterialApi
 @ExperimentalCoroutinesApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class PlayQuizScreenTest {
 
     @get:Rule(order = 0)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/quiz/QuizScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/quiz/QuizScreenTest.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import jp.mydns.kokoichi0206.common.GroupName
+import jp.mydns.kokoichi0206.data.di.DataModule
 import jp.mydns.kokoichi0206.quiz.QuizScreen
 import jp.mydns.kokoichi0206.quiz.QuizType
 import jp.mydns.kokoichi0206.quiz.TestTags
@@ -23,7 +24,7 @@ import org.junit.Test
 @ExperimentalMaterialApi
 @ExperimentalCoroutinesApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class QuizScreenTest {
 
     @get:Rule(order = 0)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/SettingTopScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/SettingTopScreenTest.kt
@@ -15,6 +15,7 @@ import jp.mydns.kokoichi0206.sakamichiapp.presentation.MainActivity
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.verify
+import jp.mydns.kokoichi0206.data.di.DataModule
 import jp.mydns.kokoichi0206.settings.SettingNavigation
 import jp.mydns.kokoichi0206.settings.SettingTopScreen
 import jp.mydns.kokoichi0206.settings.SettingsUiState
@@ -25,7 +26,7 @@ import org.junit.Test
 
 @ExperimentalMaterialApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class SettingTopScreenTest {
 
     @get:Rule(order = 0)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/SettingTopScreenVersionTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/SettingTopScreenVersionTest.kt
@@ -17,6 +17,7 @@ import jp.mydns.kokoichi0206.sakamichiapp.presentation.MainActivity
 import jp.mydns.kokoichi0206.sakamichiapp.presentation.setting.components.VersionInfo
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
+import jp.mydns.kokoichi0206.data.di.DataModule
 import jp.mydns.kokoichi0206.settings.TestTags
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
@@ -26,7 +27,7 @@ import org.junit.Test
 @ExperimentalCoroutinesApi
 @ExperimentalMaterialApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class SettingTopScreenVersionTest {
 
     @get:Rule(order = 0)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/AboutAppScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/AboutAppScreenTest.kt
@@ -18,6 +18,7 @@ import jp.mydns.kokoichi0206.settings.SettingsUiState
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.verify
+import jp.mydns.kokoichi0206.data.di.DataModule
 import jp.mydns.kokoichi0206.sakamichiapp.R
 import jp.mydns.kokoichi0206.settings.TestTags
 import jp.mydns.kokoichi0206.settings.pages.AboutAppScreen
@@ -27,7 +28,7 @@ import org.junit.Test
 
 @ExperimentalMaterialApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class AboutAppScreenTest {
     @get:Rule(order = 0)
     val hiltRule = HiltAndroidRule(this)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/CacheClearDialogTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/CacheClearDialogTest.kt
@@ -18,6 +18,7 @@ import jp.mydns.kokoichi0206.settings.SettingsUiState
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.verify
+import jp.mydns.kokoichi0206.data.di.DataModule
 import jp.mydns.kokoichi0206.settings.TestTags
 import jp.mydns.kokoichi0206.settings.pages.CacheClearDialog
 import org.junit.Before
@@ -26,7 +27,7 @@ import org.junit.Test
 
 @ExperimentalMaterialApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class CacheClearDialogTest {
 
     @get:Rule(order = 0)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/ReportIssueScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/ReportIssueScreenTest.kt
@@ -19,6 +19,7 @@ import jp.mydns.kokoichi0206.settings.SettingsViewModel
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.verify
+import jp.mydns.kokoichi0206.data.di.DataModule
 import jp.mydns.kokoichi0206.settings.TestTags
 import jp.mydns.kokoichi0206.settings.pages.ReportIssueScreen
 import org.junit.Before
@@ -27,7 +28,7 @@ import org.junit.Test
 
 @ExperimentalMaterialApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class ReportIssueScreenTest {
 
     @get:Rule(order = 0)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/SetThemeScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/SetThemeScreenTest.kt
@@ -17,6 +17,7 @@ import jp.mydns.kokoichi0206.settings.ThemeType
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.verify
+import jp.mydns.kokoichi0206.data.di.DataModule
 import jp.mydns.kokoichi0206.settings.TestTags
 import jp.mydns.kokoichi0206.settings.pages.SetThemeScreen
 import org.junit.Before
@@ -25,7 +26,7 @@ import org.junit.Test
 
 @ExperimentalMaterialApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class SetThemeScreenTest {
     @get:Rule(order = 0)
     val hiltRule = HiltAndroidRule(this)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/ShareAppScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/ShareAppScreenTest.kt
@@ -17,6 +17,7 @@ import jp.mydns.kokoichi0206.settings.SettingsUiState
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.verify
+import jp.mydns.kokoichi0206.data.di.DataModule
 import jp.mydns.kokoichi0206.sakamichiapp.R
 import jp.mydns.kokoichi0206.settings.TestTags
 import jp.mydns.kokoichi0206.settings.pages.ShareAppScreen
@@ -26,7 +27,7 @@ import org.junit.Test
 
 @ExperimentalMaterialApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class ShareAppScreenTest {
     @get:Rule(order = 0)
     val hiltRule = HiltAndroidRule(this)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/UpdateBlogScreenTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/setting/pages/UpdateBlogScreenTest.kt
@@ -16,6 +16,7 @@ import jp.mydns.kokoichi0206.settings.SettingsViewModel
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.verify
+import jp.mydns.kokoichi0206.data.di.DataModule
 import jp.mydns.kokoichi0206.settings.TestTags
 import jp.mydns.kokoichi0206.settings.pages.UpdateBlogScreen
 import org.junit.Before
@@ -24,7 +25,7 @@ import org.junit.Test
 
 @ExperimentalMaterialApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class UpdateBlogScreenTest {
 
     @get:Rule(order = 0)

--- a/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/util/BottomNavigationBarTest.kt
+++ b/app/src/androidTest/java/jp/mydns/kokoichi0206/sakamichiapp/presentation/util/BottomNavigationBarTest.kt
@@ -18,6 +18,7 @@ import jp.mydns.kokoichi0206.sakamichiapp.presentation.MainActivity
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.verify
+import jp.mydns.kokoichi0206.data.di.DataModule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
 import org.junit.Rule
@@ -26,7 +27,7 @@ import org.junit.Test
 @ExperimentalMaterialApi
 @ExperimentalCoroutinesApi
 @HiltAndroidTest
-@UninstallModules(AppModule::class)
+@UninstallModules(AppModule::class, DataModule::class)
 class BottomNavigationBarTest {
 
     @get:Rule(order = 0)

--- a/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/di/AppModule.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/sakamichiapp/di/AppModule.kt
@@ -1,30 +1,13 @@
 package jp.mydns.kokoichi0206.sakamichiapp.di
 
-import android.app.Application
-import android.content.Context
-import androidx.room.Room
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import jp.mydns.kokoichi0206.common.BuildConfigWrapper
-import jp.mydns.kokoichi0206.common.Constants
-import jp.mydns.kokoichi0206.data.local.QuizRecordDatabase
-import jp.mydns.kokoichi0206.common.interceptor.AddHeaderInterceptor
-import jp.mydns.kokoichi0206.common.interceptor.LoggingInterceptor
-import jp.mydns.kokoichi0206.common.interceptor.RetryInterceptor
-import jp.mydns.kokoichi0206.data.remote.SakamichiApi
 import jp.mydns.kokoichi0206.data.repository.QuizRecordRepository
-import jp.mydns.kokoichi0206.data.repository.QuizRecordRepositoryImpl
-import jp.mydns.kokoichi0206.data.repository.SakamichiRepository
-import jp.mydns.kokoichi0206.data.repository.SakamichiRepositoryImpl
 import jp.mydns.kokoichi0206.domain.usecase.quiz_record.*
 import jp.mydns.kokoichi0206.sakamichiapp.BuildConfig
-import jp.mydns.kokoichi0206.sakamichiapp.R
-import okhttp3.OkHttpClient
-import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
-import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 /**
@@ -33,51 +16,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
-
-    // API
-    @Provides
-    @Singleton
-    fun provideSakamichiApi(): SakamichiApi {
-        val okHttpClient = OkHttpClient.Builder()
-            // サーバー側の設定か、なぜか指定が必要！
-            .connectTimeout(777, TimeUnit.MILLISECONDS)
-            .addInterceptor(AddHeaderInterceptor())
-            .addInterceptor(LoggingInterceptor())
-            .addInterceptor(RetryInterceptor())
-            .build()
-        return Retrofit.Builder()
-            .baseUrl(Constants.BASE_URL)
-            .client(okHttpClient)
-            .addConverterFactory(GsonConverterFactory.create())
-            .build()
-            .create(SakamichiApi::class.java)
-    }
-
-    @Provides
-    @Singleton
-    fun provideSakamichiRepository(
-        api: SakamichiApi,
-        buildConfig: BuildConfigWrapper,
-    ): SakamichiRepository {
-        return SakamichiRepositoryImpl(api, buildConfig)
-    }
-
-    // Database
-    @Provides
-    @Singleton
-    fun provideQuizRecordDatabase(app: Application): QuizRecordDatabase {
-        return Room.databaseBuilder(
-            app,
-            QuizRecordDatabase::class.java,
-            QuizRecordDatabase.DATABASE_NAME
-        ).build()
-    }
-
-    @Provides
-    @Singleton
-    fun provideQuizRecordRepository(db: QuizRecordDatabase): QuizRecordRepository {
-        return QuizRecordRepositoryImpl(db.quizRecordDao)
-    }
 
     @Provides
     @Singleton

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/di/DataModule.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/di/DataModule.kt
@@ -11,12 +11,10 @@ import jp.mydns.kokoichi0206.common.Constants
 import jp.mydns.kokoichi0206.common.interceptor.AddHeaderInterceptor
 import jp.mydns.kokoichi0206.common.interceptor.LoggingInterceptor
 import jp.mydns.kokoichi0206.common.interceptor.RetryInterceptor
+import jp.mydns.kokoichi0206.data.local.MembersDatabase
 import jp.mydns.kokoichi0206.data.local.QuizRecordDatabase
 import jp.mydns.kokoichi0206.data.remote.SakamichiApi
-import jp.mydns.kokoichi0206.data.repository.QuizRecordRepository
-import jp.mydns.kokoichi0206.data.repository.QuizRecordRepositoryImpl
-import jp.mydns.kokoichi0206.data.repository.SakamichiRepository
-import jp.mydns.kokoichi0206.data.repository.SakamichiRepositoryImpl
+import jp.mydns.kokoichi0206.data.repository.*
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -73,5 +71,22 @@ object DataModule {
     @Singleton
     fun provideQuizRecordRepository(db: QuizRecordDatabase): QuizRecordRepository {
         return QuizRecordRepositoryImpl(db.quizRecordDao)
+    }
+
+    // Database
+    @Provides
+    @Singleton
+    fun provideMembersDatabase(app: Application): MembersDatabase {
+        return Room.databaseBuilder(
+            app,
+            MembersDatabase::class.java,
+            MembersDatabase.DATABASE_NAME
+        ).build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideMembersRepository(db: MembersDatabase): MembersRepository {
+        return MembersRepositoryImpl(db.membersDao)
     }
 }

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/di/DataModule.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/di/DataModule.kt
@@ -1,0 +1,77 @@
+package jp.mydns.kokoichi0206.data.di
+
+import android.app.Application
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import jp.mydns.kokoichi0206.common.BuildConfigWrapper
+import jp.mydns.kokoichi0206.common.Constants
+import jp.mydns.kokoichi0206.common.interceptor.AddHeaderInterceptor
+import jp.mydns.kokoichi0206.common.interceptor.LoggingInterceptor
+import jp.mydns.kokoichi0206.common.interceptor.RetryInterceptor
+import jp.mydns.kokoichi0206.data.local.QuizRecordDatabase
+import jp.mydns.kokoichi0206.data.remote.SakamichiApi
+import jp.mydns.kokoichi0206.data.repository.QuizRecordRepository
+import jp.mydns.kokoichi0206.data.repository.QuizRecordRepositoryImpl
+import jp.mydns.kokoichi0206.data.repository.SakamichiRepository
+import jp.mydns.kokoichi0206.data.repository.SakamichiRepositoryImpl
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+/**
+ * Dependency injection with Hilt.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object DataModule {
+
+    // API
+    @Provides
+    @Singleton
+    fun provideSakamichiApi(): SakamichiApi {
+        val okHttpClient = OkHttpClient.Builder()
+            // サーバー側の設定か、なぜか指定が必要！
+            .connectTimeout(777, TimeUnit.MILLISECONDS)
+            .addInterceptor(AddHeaderInterceptor())
+            .addInterceptor(LoggingInterceptor())
+            .addInterceptor(RetryInterceptor())
+            .build()
+        return Retrofit.Builder()
+            .baseUrl(Constants.BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(SakamichiApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSakamichiRepository(
+        api: SakamichiApi,
+        buildConfig: BuildConfigWrapper,
+    ): SakamichiRepository {
+        return SakamichiRepositoryImpl(api, buildConfig)
+    }
+
+    // Database
+    @Provides
+    @Singleton
+    fun provideQuizRecordDatabase(app: Application): QuizRecordDatabase {
+        return Room.databaseBuilder(
+            app,
+            QuizRecordDatabase::class.java,
+            QuizRecordDatabase.DATABASE_NAME
+        ).build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideQuizRecordRepository(db: QuizRecordDatabase): QuizRecordRepository {
+        return QuizRecordRepositoryImpl(db.quizRecordDao)
+    }
+}

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/local/MembersDao.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/local/MembersDao.kt
@@ -14,4 +14,12 @@ interface MembersDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertMembers(membersDao: List<MemberEntity>)
+
+    @Query(
+        value = """
+            DELETE FROM MemberEntity
+            WHERE groupName = :groupName
+        """
+    )
+    suspend fun deleteMembers(groupName: String)
 }

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/local/MembersDao.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/local/MembersDao.kt
@@ -1,0 +1,17 @@
+package jp.mydns.kokoichi0206.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import jp.mydns.kokoichi0206.data.local.model.MemberEntity
+
+@Dao
+interface MembersDao {
+
+    @Query("SELECT * FROM MemberEntity WHERE groupName = :groupName")
+    suspend fun getMembers(groupName: String): List<MemberEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertMembers(membersDao: List<MemberEntity>)
+}

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/local/MembersDatabase.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/local/MembersDatabase.kt
@@ -1,0 +1,20 @@
+package jp.mydns.kokoichi0206.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import jp.mydns.kokoichi0206.data.local.model.MemberEntity
+
+@Database(
+    entities = [MemberEntity::class],
+    version = 1,
+    exportSchema = false,
+)
+
+abstract class MembersDatabase: RoomDatabase() {
+
+    abstract val membersDao: MembersDao
+
+    companion object {
+        const val DATABASE_NAME = "members_db"
+    }
+}

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/local/model/MemberEntity.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/local/model/MemberEntity.kt
@@ -1,0 +1,29 @@
+package jp.mydns.kokoichi0206.data.local.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import jp.mydns.kokoichi0206.model.Member
+
+@Entity
+data class MemberEntity(
+    val blogUrl: String,
+    val bloodType: String,
+    val generation: String,
+    val height: String,
+    val imgUrl: String,
+    val name: String,
+    val birthday: String,
+    val groupName: String,
+    @PrimaryKey val id: Int? = null
+)
+
+fun MemberEntity.asExternalModel() = Member(
+    blogUrl = blogUrl,
+    bloodType = bloodType,
+    generation = generation,
+    height = height,
+    imgUrl = imgUrl,
+    name = name,
+    birthday = birthday,
+    group = groupName,
+)

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/local/model/MemberEntity.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/local/model/MemberEntity.kt
@@ -1,10 +1,15 @@
 package jp.mydns.kokoichi0206.data.local.model
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import jp.mydns.kokoichi0206.model.Member
 
-@Entity
+@Entity(
+    indices = [
+        Index(value = ["name"], unique = true),
+    ],
+)
 data class MemberEntity(
     val blogUrl: String,
     val bloodType: String,

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/repository/MembersRepository.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/repository/MembersRepository.kt
@@ -8,4 +8,6 @@ interface MembersRepository {
     suspend fun getMembersByGroup(group: String): List<MemberEntity>
 
     suspend fun insertMembers(members: List<Member>)
+
+    suspend fun deleteMembers(group: String)
 }

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/repository/MembersRepository.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/repository/MembersRepository.kt
@@ -1,0 +1,11 @@
+package jp.mydns.kokoichi0206.data.repository
+
+import jp.mydns.kokoichi0206.data.local.model.MemberEntity
+import jp.mydns.kokoichi0206.model.Member
+
+interface MembersRepository {
+
+    suspend fun getMembersByGroup(group: String): List<MemberEntity>
+
+    suspend fun insertMembers(members: List<Member>)
+}

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/repository/MembersRepositoryImpl.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/repository/MembersRepositoryImpl.kt
@@ -29,4 +29,8 @@ class MembersRepositoryImpl(
             )
         })
     }
+
+    override suspend fun deleteMembers(group: String) {
+        return membersDao.deleteMembers(group)
+    }
 }

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/repository/MembersRepositoryImpl.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/repository/MembersRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package jp.mydns.kokoichi0206.data.repository
+
+import jp.mydns.kokoichi0206.data.local.MembersDao
+import jp.mydns.kokoichi0206.data.local.model.MemberEntity
+import jp.mydns.kokoichi0206.model.Member
+
+/**
+ * Implementation of repository interface using actual Database query.
+ */
+class MembersRepositoryImpl(
+    private val membersDao: MembersDao
+) : MembersRepository {
+
+    override suspend fun getMembersByGroup(group: String): List<MemberEntity> {
+        return membersDao.getMembers(group)
+    }
+
+    override suspend fun insertMembers(members: List<Member>) {
+        return membersDao.insertMembers(members.map {
+            MemberEntity(
+                blogUrl = it.blogUrl,
+                bloodType = it.bloodType,
+                generation = it.generation,
+                height = it.height,
+                imgUrl = it.imgUrl,
+                name = it.name,
+                birthday = it.birthday,
+                groupName = it.group ?: "",
+            )
+        })
+    }
+}

--- a/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_members/GetMembersUseCase.kt
+++ b/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_members/GetMembersUseCase.kt
@@ -32,7 +32,7 @@ class GetMembersUseCase @Inject constructor(
                     it.asExternalModel()
                 }.let { members ->
                     if (members.isNotEmpty()) {
-                        Log.d("hoge", members.toString())
+                        Log.d(TAG, "Members of $groupName already exist.")
                         emit(Resource.Success(members))
                         return@flow
                     }

--- a/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_members/GetMembersUseCase.kt
+++ b/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_members/GetMembersUseCase.kt
@@ -39,9 +39,13 @@ class GetMembersUseCase @Inject constructor(
                 }
             }
             emit(Resource.Loading())
+            // Delete all data from local db
+            dbRepository.deleteMembers(groupName)
+            // Call API
             val members = repository.getMembers(groupName).members.map { it.toMember() }
             Log.d(TAG, "API repository.getMembers($groupName) called")
             emit(Resource.Success(members))
+            // Insert data to local db
             dbRepository.insertMembers(
                 members.map {
                     it.copy(group = groupName)

--- a/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_members/GetMembersUseCase.kt
+++ b/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_members/GetMembersUseCase.kt
@@ -1,7 +1,10 @@
 package jp.mydns.kokoichi0206.domain.usecase.get_members
 
+import android.util.Log
 import jp.mydns.kokoichi0206.common.Resource
+import jp.mydns.kokoichi0206.data.local.model.asExternalModel
 import jp.mydns.kokoichi0206.data.remote.dto.toMember
+import jp.mydns.kokoichi0206.data.repository.MembersRepository
 import jp.mydns.kokoichi0206.data.repository.SakamichiRepository
 import jp.mydns.kokoichi0206.model.Member
 import kotlinx.coroutines.flow.Flow
@@ -15,13 +18,28 @@ import javax.inject.Inject
  */
 class GetMembersUseCase @Inject constructor(
     private val repository: SakamichiRepository,
+    private val dbRepository: MembersRepository,
 ) {
     // ここで Members -> List<Member> に変えている
     operator fun invoke(groupName: String): Flow<Resource<List<Member>>> = flow {
         try {
+            dbRepository.getMembersByGroup(groupName).map {
+                it.asExternalModel()
+            }.let { members ->
+                if (members.isNotEmpty()) {
+                    Log.d("hoge", members.toString())
+                    emit(Resource.Success(members))
+                    return@flow
+                }
+            }
             emit(Resource.Loading())
             val members = repository.getMembers(groupName).members.map { it.toMember() }
             emit(Resource.Success(members))
+            dbRepository.insertMembers(
+                members.map {
+                    it.copy(group = groupName)
+                }
+            )
         } catch (e: HttpException) {
             emit(Resource.Error(e.localizedMessage ?: "An unexpected error occurred."))
         } catch (e: IOException) {

--- a/feature/member_list/src/main/java/jp/mydns/kokoichi0206/member_list/MemberListScreen.kt
+++ b/feature/member_list/src/main/java/jp/mydns/kokoichi0206/member_list/MemberListScreen.kt
@@ -46,7 +46,7 @@ fun MemberListScreen(
         MainView(
             uiState,
             onRefresh = {
-                viewModel.setApiMembers()
+                viewModel.setApiMembers(force = true)
             },
             onPersonClick,
             onGroupClicked = { gn ->

--- a/feature/member_list/src/main/java/jp/mydns/kokoichi0206/member_list/MemberListViewModel.kt
+++ b/feature/member_list/src/main/java/jp/mydns/kokoichi0206/member_list/MemberListViewModel.kt
@@ -32,9 +32,9 @@ open class MemberListViewModel @Inject constructor(
      *
      * @param groupName group name (one of the GroupName enum)
      */
-    fun getMembers(groupName: GroupName) {
+    fun getMembers(groupName: GroupName, force: Boolean = false) {
         _uiState.update { it.copy(isLoading = true, error = "") }
-        getMembersUseCase(groupName.name.lowercase()).onEach { result ->
+        getMembersUseCase(groupName.name.lowercase(), force).onEach { result ->
             when (result) {
                 is Resource.Success -> {
                     _apiState.value =
@@ -140,7 +140,7 @@ open class MemberListViewModel @Inject constructor(
         if (nKey == NarrowKeys.NONE) {
             _uiState.value.visibleMembers = _apiState.value.members
         } else {
-            val target = when(nKey) {
+            val target = when (nKey) {
                 NarrowKeys.FIRST_GEN -> "1期生"
                 NarrowKeys.SECOND_GEN -> "2期生"
                 NarrowKeys.THIRD_GEN -> "3期生"
@@ -186,9 +186,9 @@ open class MemberListViewModel @Inject constructor(
     /**
      * Reset the members (in apiState) using groupName (in uiState).
      */
-    fun setApiMembers() {
+    fun setApiMembers(force: Boolean = false) {
         setVisibleMembers(mutableListOf())
-        getMembers(uiState.value.groupName)
+        getMembers(uiState.value.groupName, force)
 
         // TODO: Consider what logic is the best.
         resetOptions()


### PR DESCRIPTION
## Issue 番号
#90 

## 対応内容・対応背景
- 

## やったこと
- Members API をキャッシュするよう変更
  - キャッシュするための Room DBを作成
  - ローカル DB に値がなければ API を呼ぶ
  - [onRefresh](https://developer.android.com/training/swipe/respond-refresh-request?hl=ja) による手動更新時には、強制的に API を呼ぶ

## やってないこと
- Members 以外の API に対するキャッシュ対応
- Network が取れない時の対応
  - refresh した時、ネットワークが悪ければ強制 refresh させないようにしたい
  - いやどうだろ、後で整理しないと

## UI before / after

## テスト観点

以下を確認

- ローカルに値がある時、API が呼び出されないこと
- API を連続で読んでも、重複してデータが保存されないこと
- リモートの値が更新された時、ローカルの値がそちらに合わせられること
  - リモートが正
  - このために全てのデータを消すのは最低限の作戦。。。

## 補足
