### PR TITLE
converter として Gson ではなく Moshi を使うよう変更

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,7 +122,6 @@ dependencies {
 
     // Retrofit
     implementation deps.retrofit.retrofit
-    implementation deps.retrofit.gson
     implementation deps.retrofit.rxjava2
     implementation deps.retrofit.mock
     implementation deps.okhttp3.okhttp

--- a/core/data/build.gradle
+++ b/core/data/build.gradle
@@ -17,7 +17,7 @@ android {
 }
 
 dependencies {
-    implementation deps.retrofit.gson
+    implementation deps.retrofit.moshi
     implementation deps.timber
     implementation deps.okhttp3.okhttp
     implementation deps.okhttp3.logging_interceptor

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/di/DataModule.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/di/DataModule.kt
@@ -17,7 +17,7 @@ import jp.mydns.kokoichi0206.data.remote.SakamichiApi
 import jp.mydns.kokoichi0206.data.repository.*
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.converter.moshi.MoshiConverterFactory
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -42,7 +42,7 @@ object DataModule {
         return Retrofit.Builder()
             .baseUrl(Constants.BASE_URL)
             .client(okHttpClient)
-            .addConverterFactory(GsonConverterFactory.create())
+            .addConverterFactory(MoshiConverterFactory.create().failOnUnknown())
             .build()
             .create(SakamichiApi::class.java)
     }

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/remote/dto/Member.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/remote/dto/Member.kt
@@ -1,23 +1,23 @@
 package jp.mydns.kokoichi0206.data.remote.dto
 
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
 
 /**
  * Data class for one member in the API.
  */
 data class MemberDto(
     val birthday: String,
-    @SerializedName("blog_url")
+    @field:Json(name = "blog_url")
     val blogUrl: String,
-    @SerializedName("blood_type")
+    @field:Json(name = "blood_type")
     val bloodType: String,
     val generation: String,
     val height: String,
-    @SerializedName("img_url")
+    @field:Json(name = "img_url")
     val imgUrl: String,
-    @SerializedName("user_id")
+    @field:Json(name = "user_id")
     val userId: Int,
-    @SerializedName("user_name")
+    @field:Json(name = "user_name")
     val nameName: String
 )
 

--- a/core/domain/build.gradle
+++ b/core/domain/build.gradle
@@ -18,6 +18,7 @@ android {
 
 dependencies {
     implementation deps.retrofit.retrofit
+    implementation deps.retrofit.moshi
 
     // hilt dependencies
     implementation deps.hilt.android
@@ -26,7 +27,6 @@ dependencies {
     implementation deps.hilt.navigation
 
     implementation deps.coroutines.core
-    implementation deps.retrofit.gson
     implementation deps.room.room
 
     // modules dependency

--- a/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_blogs/GetBlogsUseCase.kt
+++ b/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_blogs/GetBlogsUseCase.kt
@@ -1,5 +1,7 @@
 package jp.mydns.kokoichi0206.domain.usecase.get_blogs
 
+import com.squareup.moshi.JsonDataException
+import jp.mydns.kokoichi0206.common.Resource
 import jp.mydns.kokoichi0206.data.remote.dto.toBlog
 import jp.mydns.kokoichi0206.data.repository.SakamichiRepository
 import jp.mydns.kokoichi0206.model.Blog
@@ -17,13 +19,15 @@ class GetBlogsUseCase @Inject constructor(
 ) {
     operator fun invoke(groupName: String): Flow<jp.mydns.kokoichi0206.common.Resource<List<Blog>>> = flow {
         try {
-            emit(jp.mydns.kokoichi0206.common.Resource.Loading())
+            emit(Resource.Loading())
             val members = repository.getBlogs(groupName).blogs.map { it.toBlog() }
-            emit(jp.mydns.kokoichi0206.common.Resource.Success(members))
+            emit(Resource.Success(members))
         } catch (e: HttpException) {
-            emit(jp.mydns.kokoichi0206.common.Resource.Error(e.localizedMessage ?: "An unexpected error occurred."))
+            emit(Resource.Error(e.localizedMessage ?: "An unexpected error occurred."))
         } catch (e: IOException) {
-            emit(jp.mydns.kokoichi0206.common.Resource.Error("Couldn't reach server. Check your network connection"))
+            emit(Resource.Error("Couldn't reach server. Check your network connection"))
+        } catch (e: JsonDataException) {
+            emit(Resource.Error("Something unexpected happened at server.\nPlease report to us."))
         }
     }
 }

--- a/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_members/GetMembersUseCase.kt
+++ b/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_members/GetMembersUseCase.kt
@@ -1,6 +1,7 @@
 package jp.mydns.kokoichi0206.domain.usecase.get_members
 
 import android.util.Log
+import com.squareup.moshi.JsonDataException
 import jp.mydns.kokoichi0206.common.Resource
 import jp.mydns.kokoichi0206.data.local.model.asExternalModel
 import jp.mydns.kokoichi0206.data.remote.dto.toMember
@@ -54,7 +55,9 @@ class GetMembersUseCase @Inject constructor(
         } catch (e: HttpException) {
             emit(Resource.Error(e.localizedMessage ?: "An unexpected error occurred."))
         } catch (e: IOException) {
-            emit(Resource.Error("Couldn't reach server. Check your network connection"))
+            emit(Resource.Error("Couldn't reach server. Check your network connection."))
+        } catch (e: JsonDataException) {
+            emit(Resource.Error("Something unexpected happened at server.\nPlease report to us."))
         }
     }
 }

--- a/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_positions/GetPositionsUseCase.kt
+++ b/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_positions/GetPositionsUseCase.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.domain.usecase.get_positions
 
+import com.squareup.moshi.JsonDataException
 import jp.mydns.kokoichi0206.common.Resource
 import jp.mydns.kokoichi0206.data.remote.dto.toPosition
 import jp.mydns.kokoichi0206.data.repository.SakamichiRepository
@@ -24,6 +25,8 @@ class GetPositionsUseCase @Inject constructor(
             emit(Resource.Error<List<jp.mydns.kokoichi0206.model.Position>>(e.localizedMessage ?: "An unexpected error occurred."))
         } catch (e: IOException) {
             emit(Resource.Error<List<jp.mydns.kokoichi0206.model.Position>>("Couldn't reach server. Check your network connection"))
+        } catch (e: JsonDataException) {
+            emit(Resource.Error("Something unexpected happened at server.\nPlease report to us."))
         }
     }
 }

--- a/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_songs/GetSongsUseCase.kt
+++ b/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/get_songs/GetSongsUseCase.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.domain.usecase.get_songs
 
+import com.squareup.moshi.JsonDataException
 import jp.mydns.kokoichi0206.common.Resource
 import jp.mydns.kokoichi0206.data.remote.dto.toSong
 import jp.mydns.kokoichi0206.data.repository.SakamichiRepository
@@ -25,6 +26,8 @@ class GetSongsUseCase @Inject constructor(
             emit(Resource.Error<List<jp.mydns.kokoichi0206.model.Song>>(e.localizedMessage ?: "An unexpected error occurred."))
         } catch (e: IOException) {
             emit(Resource.Error<List<jp.mydns.kokoichi0206.model.Song>>("Couldn't reach server. Check your network connection"))
+        } catch (e: JsonDataException) {
+            emit(Resource.Error("Something unexpected happened at server.\nPlease report to us."))
         }
     }
 }

--- a/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/other_api/ReportIssueUseCase.kt
+++ b/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/other_api/ReportIssueUseCase.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.domain.usecase.other_api
 
+import com.squareup.moshi.JsonDataException
 import jp.mydns.kokoichi0206.common.Resource
 import jp.mydns.kokoichi0206.data.remote.dto.toReportIssueResponse
 import jp.mydns.kokoichi0206.data.repository.SakamichiRepository
@@ -26,6 +27,8 @@ class ReportIssueUseCase @Inject constructor(
             )
         } catch (e: IOException) {
             emit(Resource.Error<jp.mydns.kokoichi0206.model.ReportIssueResponse>("Couldn't reach server. Check your network connection"))
+        } catch (e: JsonDataException) {
+            emit(Resource.Error("Something unexpected happened at server.\nPlease report to us."))
         }
     }
 }

--- a/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/other_api/UpdateBlogUseCase.kt
+++ b/core/domain/src/main/java/jp/mydns/kokoichi0206/domain/usecase/other_api/UpdateBlogUseCase.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.domain.usecase.other_api
 
+import com.squareup.moshi.JsonDataException
 import jp.mydns.kokoichi0206.common.Resource
 import jp.mydns.kokoichi0206.data.remote.dto.toUpdateBlogResponse
 import jp.mydns.kokoichi0206.data.repository.SakamichiRepository
@@ -22,6 +23,8 @@ class UpdateBlogUseCase @Inject constructor(
             emit(Resource.Error<jp.mydns.kokoichi0206.model.UpdateBlogResponse>(e.localizedMessage ?: "An unexpected error occurred."))
         } catch (e: IOException) {
             emit(Resource.Error<jp.mydns.kokoichi0206.model.UpdateBlogResponse>("Couldn't reach server. Check your network connection"))
+        } catch (e: JsonDataException) {
+            emit(Resource.Error("Something unexpected happened at server.\nPlease report to us."))
         }
     }
 }

--- a/core/model/build.gradle
+++ b/core/model/build.gradle
@@ -18,7 +18,6 @@ android {
 
 dependencies {
     implementation deps.room.room
-    implementation deps.retrofit.gson
 
     // modules
     implementation project(":core:common")

--- a/feature/member_detail/build.gradle
+++ b/feature/member_detail/build.gradle
@@ -51,8 +51,6 @@ dependencies {
     // Coil
     implementation deps.coil
 
-    implementation deps.retrofit.gson
-
     // Inject
     implementation deps.hilt.android
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -102,7 +102,7 @@ deps.arch = arch
 
 def retrofit = [:]
 retrofit.retrofit = "com.squareup.retrofit2:retrofit:$versions.retrofit"
-retrofit.gson = "com.squareup.retrofit2:converter-gson:$versions.retrofit"
+retrofit.moshi = "com.squareup.retrofit2:converter-moshi:$versions.retrofit"
 retrofit.rxjava2 = "com.squareup.retrofit2:adapter-rxjava2:$versions.adapter_rxjava"
 retrofit.mock = "com.squareup.retrofit2:retrofit-mock:$versions.retrofit"
 deps.retrofit = retrofit


### PR DESCRIPTION
## Issue 番号

Closed #84 

## 対応内容・対応背景
- API_KEY が有効でない時、ぬるぽが発生していた
- 根本原因としてはサーバー側の問題だったが、今後デコードできなかった時のために対応を行った

## やったこと
- Moshi のライブラリを使って、ステータスコードが正常 + **デコードに失敗**した時にエラーを吐かせるように変更
- そのエラーを捕捉することで、ぬるぽを防ぐようにした

## やってないこと
- 

## UI before / after

status code 200 + デコードに失敗した時の画面。

**再現方法**
api_key が失敗した時などのステータスコードを 200 に変更する

<img width="310" alt="Screenshot 2022-11-22 at 21 46 53" src="https://user-images.githubusercontent.com/52474650/203317559-0624a7e7-868c-49d1-9cd3-de71da6e5ab4.png">

## テスト観点

## 補足
