### PR TITLE
Data module に対するテスト

### DIFF
--- a/app/src/test/java/jp/mydns/kokoichi0206/data/remote/SakamichiApiImplTest.kt
+++ b/app/src/test/java/jp/mydns/kokoichi0206/data/remote/SakamichiApiImplTest.kt
@@ -1,0 +1,84 @@
+package jp.mydns.kokoichi0206.data.remote
+
+import com.squareup.moshi.JsonDataException
+import jp.mydns.kokoichi0206.data.remote.dto.MemberDto
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import java.net.HttpURLConnection
+
+class SakamichiApiImplTest {
+
+    private val mockWebServer = MockWebServer()
+
+    lateinit var api: SakamichiApi
+
+    @Before
+    fun setUp() {
+        api = createSakamichiApi(mockWebServer.url("/").toString())
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `get_members success`() = runBlocking {
+        // Arrange
+        val response = MockResponse()
+            .setBody("{\"members\":[{\"user_id\":0,\"user_name\":\"名前 です\",\"birthday\":\"12/26/1997\",\"height\":\"157.5cm\",\"blood_type\":\"Type O\",\"generation\":\"1st generation\",\"blog_url\":\"https://hinatazaka46.com/s/official/diary/member/list?ima=0000\\u0026ct=2\",\"img_url\":\"https://kokoichi0206.mydns.jp/imgs/hinata/namae.jpeg\"}]}")
+            .setResponseCode(HttpURLConnection.HTTP_OK)
+        mockWebServer.enqueue(response)
+        val expected = listOf(
+            MemberDto(
+                birthday = "12/26/1997",
+                blogUrl = "https://hinatazaka46.com/s/official/diary/member/list?ima=0000&ct=2",
+                bloodType = "Type O",
+                generation = "1st generation",
+                height = "157.5cm",
+                imgUrl = "https://kokoichi0206.mydns.jp/imgs/hinata/namae.jpeg",
+                userId = 0,
+                nameName = "名前 です",
+            )
+        )
+
+        // Act
+        val resp = api.getMembers(
+            groupName = "hinatazaka",
+            apiKey = "valid_api_key",
+        )
+
+        // Assert
+        assertNotNull(resp)
+        assertEquals(expected, resp.members)
+
+        val recordedRequest = mockWebServer.takeRequest()
+        assertEquals("GET", recordedRequest.method)
+        assertEquals("/api/v1/members?gn=hinatazaka&key=valid_api_key", recordedRequest.path)
+    }
+
+    @Test(expected = JsonDataException::class)
+    fun `get_members with undecodable response should throw exception`() = runBlocking {
+        // Arrange
+        val response = MockResponse()
+            .setBody("{\"error\":\"Something unexpected happened.\"}")
+            .setResponseCode(HttpURLConnection.HTTP_OK)
+        mockWebServer.enqueue(response)
+
+        // Act
+        val resp = api.getMembers(
+            groupName = "hinatazaka",
+            apiKey = "valid_api_key",
+        )
+
+        // Assert
+        // Exception 'moshi.JsonDataException' is expected
+        // and this is checked in @Test annotation.
+    }
+}

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/di/DataModule.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/di/DataModule.kt
@@ -8,17 +8,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import jp.mydns.kokoichi0206.common.BuildConfigWrapper
 import jp.mydns.kokoichi0206.common.Constants
-import jp.mydns.kokoichi0206.common.interceptor.AddHeaderInterceptor
-import jp.mydns.kokoichi0206.common.interceptor.LoggingInterceptor
-import jp.mydns.kokoichi0206.common.interceptor.RetryInterceptor
 import jp.mydns.kokoichi0206.data.local.MembersDatabase
 import jp.mydns.kokoichi0206.data.local.QuizRecordDatabase
 import jp.mydns.kokoichi0206.data.remote.SakamichiApi
+import jp.mydns.kokoichi0206.data.remote.createSakamichiApi
 import jp.mydns.kokoichi0206.data.repository.*
-import okhttp3.OkHttpClient
-import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
-import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 /**
@@ -32,19 +26,7 @@ object DataModule {
     @Provides
     @Singleton
     fun provideSakamichiApi(): SakamichiApi {
-        val okHttpClient = OkHttpClient.Builder()
-            // サーバー側の設定か、なぜか指定が必要！
-            .connectTimeout(777, TimeUnit.MILLISECONDS)
-            .addInterceptor(AddHeaderInterceptor())
-            .addInterceptor(LoggingInterceptor())
-            .addInterceptor(RetryInterceptor())
-            .build()
-        return Retrofit.Builder()
-            .baseUrl(Constants.BASE_URL)
-            .client(okHttpClient)
-            .addConverterFactory(MoshiConverterFactory.create().failOnUnknown())
-            .build()
-            .create(SakamichiApi::class.java)
+        return createSakamichiApi(Constants.BASE_URL)
     }
 
     @Provides

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/remote/SakamichiApiImpl.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/remote/SakamichiApiImpl.kt
@@ -1,0 +1,30 @@
+package jp.mydns.kokoichi0206.data.remote
+
+import jp.mydns.kokoichi0206.common.interceptor.AddHeaderInterceptor
+import jp.mydns.kokoichi0206.common.interceptor.LoggingInterceptor
+import jp.mydns.kokoichi0206.common.interceptor.RetryInterceptor
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.TimeUnit
+
+/**
+ * Create a SakamichiApi Impl.
+ */
+fun createSakamichiApi(
+    baseURL: String,
+): SakamichiApi {
+    val okHttpClient = OkHttpClient.Builder()
+        // サーバー側の設定か、なぜか指定が必要！
+        .connectTimeout(777, TimeUnit.MILLISECONDS)
+        .addInterceptor(AddHeaderInterceptor())
+        .addInterceptor(LoggingInterceptor())
+        .addInterceptor(RetryInterceptor())
+        .build()
+    return Retrofit.Builder()
+        .baseUrl(baseURL)
+        .client(okHttpClient)
+        .addConverterFactory(MoshiConverterFactory.create().failOnUnknown())
+        .build()
+        .create(SakamichiApi::class.java)
+}


### PR DESCRIPTION
## Issue 番号

## 対応内容・対応背景

- #84 で、デコードが失敗した時にぬるぽでクラッシュする障害があった
- これが直ってるかどうかのテストを記述したい
- せっかくなら、data module の他のテストも作る

## やったこと

- mockWebServer を使って Retrofit API のテスト
  - 結局 converter のテストみたいになった。。。
- Dao のテストは既に１ファイルあった

## やってないこと

- 

## UI before / after

## テスト観点

## 補足

- [Android Unit Test Room Database – Testing Room DAOs](https://www.simplifiedcoding.net/android-unit-test-room-database/)
- [Unit Test Retrofit API calls with MockWebServer](https://sachinkmr375.medium.com/unit-test-retrofit-api-calls-with-mockwebserver-bbb9f66a78a6)
