### PR TITLE
API 取得が失敗する問題を解決

### DIFF
--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/remote/dto/BlogsDto.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/remote/dto/BlogsDto.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.data.remote.dto
 
 data class BlogsDto(
-    val blogs: List<BlogDto>
+    val counts: Int,
+    val blogs: List<BlogDto>,
 )

--- a/core/data/src/main/java/jp/mydns/kokoichi0206/data/remote/dto/MembersDto.kt
+++ b/core/data/src/main/java/jp/mydns/kokoichi0206/data/remote/dto/MembersDto.kt
@@ -4,5 +4,6 @@ package jp.mydns.kokoichi0206.data.remote.dto
  * Data class for members API.
  */
 data class MembersDto(
-    val members: List<MemberDto>
+    val counts: Int,
+    val members: List<MemberDto>,
 )


### PR DESCRIPTION
## Issue 番号

Closed #99 

## 対応内容・対応背景
- ある時確認してみると、API 通信に失敗するようになってた

## やったこと
- API のレスポンスに counts を追加したことが原因ぽかった
- counts を parse する model に追加した

## やってないこと
- 

## UI before / after

## テスト観点

## 補足
