### PR TITLE
推しメン機能の実装

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,41 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.0-release" />
+  </component>
+</project>

--- a/core/common/src/main/java/jp/mydns/kokoichi0206/common/datamanager/DataStoreManager.kt
+++ b/core/common/src/main/java/jp/mydns/kokoichi0206/common/datamanager/DataStoreManager.kt
@@ -25,6 +25,8 @@ object DataStoreManager {
     const val KEY_IS_DEVELOPER = "is_developer"
     const val KEY_THEME_GROUP = "theme_type"
     const val KEY_USER_ID = "user_id"
+    const val KEY_FAVE_NAME = "fave_name"
+    const val KEY_FAVE_URI = "fave_uri"
 
     suspend fun writeBoolean(context: Context, key: String, value: Boolean) =
         withContext(Dispatchers.IO) {

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingScreen.kt
@@ -14,4 +14,5 @@ sealed class SettingScreen(val route: String) {
     object AboutAppScreen : SettingScreen("about_app")
     object MyFaveScreen : SettingScreen("my_fave")
     object MyFaveSettingScreen : SettingScreen("my_fave_setting")
+    object MyFaveSettingConfirmScreen : SettingScreen("my_fave_setting_confirm")
 }

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingScreen.kt
@@ -12,4 +12,5 @@ sealed class SettingScreen(val route: String) {
     object SetThemeScreen : SettingScreen("set_theme")
     object ShareAppScreen : SettingScreen("share_app")
     object AboutAppScreen : SettingScreen("about_app")
+    object MyFaveScreen : SettingScreen("my_fave")
 }

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingScreen.kt
@@ -13,4 +13,5 @@ sealed class SettingScreen(val route: String) {
     object ShareAppScreen : SettingScreen("share_app")
     object AboutAppScreen : SettingScreen("about_app")
     object MyFaveScreen : SettingScreen("my_fave")
+    object MyFaveSettingScreen : SettingScreen("my_fave_setting")
 }

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
@@ -9,6 +9,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.*
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -165,17 +168,31 @@ fun SettingsRouting(
                 uiState = uiState,
             )
         }
+
         composable(SettingScreen.MyFaveScreen.route) {
             FaveScreen(
                 navController = navController,
                 uiState = uiState,
             )
         }
+        var selected = uiState.fave
         composable(SettingScreen.MyFaveSettingScreen.route) {
             FaveSettingScreen(
                 navController = navController,
                 uiState = uiState,
+                onConfirmClicked = {
+                    selected = it
+                    navController.navigate(SettingScreen.MyFaveSettingConfirmScreen.route)
+                }
             )
+        }
+        composable(SettingScreen.MyFaveSettingConfirmScreen.route) {
+            selected?.let {
+                FaveSettingConfirmScreen(
+                    uiState = uiState,
+                    selected = it,
+                )
+            }
         }
     }
 }

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
@@ -96,6 +96,7 @@ fun SettingsRouting(
             SettingNavigation.SetTheme,
             SettingNavigation.ShareApp,
             SettingNavigation.AboutApp,
+            SettingNavigation.MyFave,
         )
 
         composable(
@@ -164,6 +165,9 @@ fun SettingsRouting(
                 uiState = uiState,
             )
         }
+        composable(SettingScreen.MyFaveScreen.route) {
+            FaveScreen()
+        }
     }
 }
 
@@ -208,6 +212,11 @@ sealed class SettingNavigation(
     object AboutApp : SettingNavigation(
         name = R.string.setting_about_app,
         route = SettingScreen.AboutAppScreen.route
+    )
+
+    object MyFave : SettingNavigation(
+        name = R.string.my_fave,
+        route = SettingScreen.MyFaveScreen.route
     )
 }
 

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
@@ -207,8 +207,10 @@ fun SettingsRouting(
                     selected = it,
                     onConfirmClicked = {
                         onConfirmClicked(it)
-                        navController.navigate(SettingScreen.MyFaveScreen.route)
-                    }
+                    },
+                    onCancelClicked = {
+                        navController.popBackStack()
+                    },
                 )
             }
         }

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
@@ -1,28 +1,24 @@
 package jp.mydns.kokoichi0206.settings
 
+import android.net.Uri
 import androidx.compose.animation.*
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.*
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.google.accompanist.navigation.animation.composable
 import com.google.accompanist.navigation.animation.AnimatedNavHost
+import com.google.accompanist.navigation.animation.composable
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import jp.mydns.kokoichi0206.common.Constants
 import jp.mydns.kokoichi0206.common.ui.theme.CustomSakaTheme
 import jp.mydns.kokoichi0206.feature.settings.R
+import jp.mydns.kokoichi0206.model.Member
 import jp.mydns.kokoichi0206.settings.pages.*
 
 @ExperimentalAnimationApi
@@ -39,6 +35,8 @@ fun SettingsScreen(
         viewModel.readAppName()
         viewModel.readUserID(context)
         viewModel.readThemeFromDataStore(context)
+        viewModel.initAllMembers()
+        viewModel.readFavesFromDataStore(context)
     }
 
     CustomSakaTheme {
@@ -57,7 +55,16 @@ fun SettingsScreen(
             setThemeType = { type ->
                 viewModel.setThemeType(type)
                 viewModel.writeTheme(context, type.name)
-            }
+            },
+            onFaveNavigated = {
+                viewModel.readFavesFromDataStore(context)
+            },
+            onImageSelected = {
+                viewModel.writeFaveUri(context, it.toString())
+            },
+            onConfirmClicked = {
+                viewModel.selected(context, it)
+            },
         )
     }
 }
@@ -71,6 +78,9 @@ fun SettingsRouting(
     onUpdateClicked: () -> Unit = {},
     reportIssue: (String) -> Unit = {},
     setThemeType: (ThemeType) -> Unit = {},
+    onFaveNavigated: () -> Unit = {},
+    onImageSelected: (Uri) -> Unit = {},
+    onConfirmClicked: (Member) -> Unit = {},
 ) {
     val navController = rememberAnimatedNavController()
 
@@ -172,6 +182,10 @@ fun SettingsRouting(
         composable(SettingScreen.MyFaveScreen.route) {
             FaveScreen(
                 navController = navController,
+                onFaveNavigated = onFaveNavigated,
+                onImageSelected = {
+                    onImageSelected(it)
+                },
                 uiState = uiState,
             )
         }
@@ -191,6 +205,10 @@ fun SettingsRouting(
                 FaveSettingConfirmScreen(
                     uiState = uiState,
                     selected = it,
+                    onConfirmClicked = {
+                        onConfirmClicked(it)
+                        navController.navigate(SettingScreen.MyFaveScreen.route)
+                    }
                 )
             }
         }

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
@@ -166,7 +166,10 @@ fun SettingsRouting(
             )
         }
         composable(SettingScreen.MyFaveScreen.route) {
-            FaveScreen()
+            FaveScreen(
+                navController = navController,
+                uiState = uiState,
+            )
         }
     }
 }

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
@@ -89,8 +89,19 @@ fun SettingsRouting(
         modifier = Modifier.fillMaxSize(),
         startDestination = SettingScreen.SettingTopScreen.route,
         enterTransition = {
+            val direction =
+                if (
+                    (initialState.destination.route == SettingScreen.MyFaveSettingConfirmScreen.route && targetState.destination.route == SettingScreen.MyFaveSettingScreen.route) ||
+                    (initialState.destination.route == SettingScreen.MyFaveSettingScreen.route && targetState.destination.route == SettingScreen.MyFaveScreen.route) ||
+                    (initialState.destination.route == SettingScreen.MyFaveSettingConfirmScreen.route && targetState.destination.route == SettingScreen.MyFaveScreen.route)
+                ) {
+                    AnimatedContentScope.SlideDirection.Right
+                } else {
+                    // Default
+                    AnimatedContentScope.SlideDirection.Left
+                }
             slideIntoContainer(
-                AnimatedContentScope.SlideDirection.Left,
+                direction,
                 animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS)
             ) + fadeIn(animationSpec = tween(Constants.NAVIGATION_DURATION_MILLIS))
         },
@@ -207,6 +218,10 @@ fun SettingsRouting(
                     selected = it,
                     onConfirmClicked = {
                         onConfirmClicked(it)
+
+                        // back to setting screen
+                        navController.navigateUp()
+                        navController.navigateUp()
                     },
                     onCancelClicked = {
                         navController.popBackStack()

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsScreen.kt
@@ -171,6 +171,12 @@ fun SettingsRouting(
                 uiState = uiState,
             )
         }
+        composable(SettingScreen.MyFaveSettingScreen.route) {
+            FaveSettingScreen(
+                navController = navController,
+                uiState = uiState,
+            )
+        }
     }
 }
 

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsUiState.kt
@@ -13,6 +13,7 @@ data class SettingsUiState(
     val userId: String = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     val appName: String = "my.app",
     val fave: Member? = null,
+    val allMembers: List<Member> = mutableListOf(),
 )
 
 data class Record(

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsUiState.kt
@@ -1,6 +1,7 @@
 package jp.mydns.kokoichi0206.settings
 
 import android.content.Context
+import android.net.Uri
 import androidx.compose.ui.graphics.Color
 import jp.mydns.kokoichi0206.common.datamanager.DataStoreManager
 import jp.mydns.kokoichi0206.common.ui.theme.*
@@ -13,6 +14,7 @@ data class SettingsUiState(
     val userId: String = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     val appName: String = "my.app",
     val fave: Member? = null,
+    val faveURI: Uri? = null,
     val allMembers: List<Member> = mutableListOf(),
 )
 

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/SettingsUiState.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.ui.graphics.Color
 import jp.mydns.kokoichi0206.common.datamanager.DataStoreManager
 import jp.mydns.kokoichi0206.common.ui.theme.*
+import jp.mydns.kokoichi0206.model.Member
 
 data class SettingsUiState(
     val records: MutableList<Record> = mutableListOf(),
@@ -11,6 +12,7 @@ data class SettingsUiState(
     val version: String = "1.0.0",
     val userId: String = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     val appName: String = "my.app",
+    val fave: Member? = null,
 )
 
 data class Record(

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveScreen.kt
@@ -1,5 +1,6 @@
 package jp.mydns.kokoichi0206.settings.pages
 
+import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -72,6 +73,8 @@ fun FaveScreen(
         )
     }
 
+    val context = LocalContext.current
+
     val singlePhotoPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia(),
         onResult = { uri ->
@@ -79,11 +82,15 @@ fun FaveScreen(
                 imgUri = it
 
                 onImageSelected(uri)
+
+                context.contentResolver.takePersistableUriPermission(
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
             }
         },
     )
 
-    val context = LocalContext.current
 
     val size = 240.dp
 

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveScreen.kt
@@ -1,0 +1,18 @@
+package jp.mydns.kokoichi0206.settings.pages
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import jp.mydns.kokoichi0206.common.ui.theme.CustomSakaTheme
+
+@Composable
+fun FaveScreen() {
+
+}
+
+@Preview
+@Composable
+fun FaveScreenPreview() {
+    CustomSakaTheme() {
+        FaveScreen()
+    }
+}

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveScreen.kt
@@ -33,6 +33,7 @@ import coil.compose.AsyncImage
 import jp.mydns.kokoichi0206.common.ui.theme.CustomSakaTheme
 import jp.mydns.kokoichi0206.feature.settings.R
 import jp.mydns.kokoichi0206.model.Member
+import jp.mydns.kokoichi0206.settings.SettingScreen
 import jp.mydns.kokoichi0206.settings.SettingsUiState
 import jp.mydns.kokoichi0206.settings.components.SettingTopBar
 
@@ -98,7 +99,9 @@ fun FaveScreen(
         Text(
             modifier = Modifier
                 .background(uiState.themeType.subColor)
-                .clickable { }
+                .clickable {
+                    navController.navigate(SettingScreen.MyFaveSettingScreen.route)
+                }
                 .padding(16.dp),
             text = context.resources.getString(R.string.my_fave_set_member),
             fontSize = 24.sp,

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveScreen.kt
@@ -1,18 +1,129 @@
 package jp.mydns.kokoichi0206.settings.pages
 
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import coil.compose.AsyncImage
 import jp.mydns.kokoichi0206.common.ui.theme.CustomSakaTheme
+import jp.mydns.kokoichi0206.feature.settings.R
+import jp.mydns.kokoichi0206.model.Member
+import jp.mydns.kokoichi0206.settings.SettingsUiState
+import jp.mydns.kokoichi0206.settings.components.SettingTopBar
 
 @Composable
-fun FaveScreen() {
+fun FaveScreen(
+    navController: NavHostController,
+    uiState: SettingsUiState,
+) {
+    // Top Bar
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+    ) {
+        SettingTopBar(
+            themeType = uiState.themeType,
+            text = stringResource(id = R.string.my_fave),
+            onArrowClick = {
+                navController.popBackStack()
+            }
+        )
+    }
 
+    val member = uiState.fave
+
+    var imgUri by remember {
+        mutableStateOf<Uri?>(null)
+    }
+
+    member?.let {
+        imgUri = Uri.parse(member.imgUrl)
+    }
+
+    val context = LocalContext.current
+
+    val size = 240.dp
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        AsyncImage(
+            modifier = Modifier
+                .size(size)
+                .border(
+                    width = 3.dp,
+                    color = Color.Gray.copy(alpha = 0.3f),
+                ),
+            model = imgUri,
+            contentDescription = "my fave's picture",
+            contentScale = ContentScale.Crop,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = member?.name ?: "46",
+            fontSize = 36.sp,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            modifier = Modifier
+                .background(uiState.themeType.subColor)
+                .clickable { }
+                .padding(16.dp),
+            text = context.resources.getString(R.string.my_fave_set_member),
+            fontSize = 24.sp,
+            color = uiState.themeType.fontColor,
+        )
+    }
 }
 
 @Preview
 @Composable
 fun FaveScreenPreview() {
-    CustomSakaTheme() {
-        FaveScreen()
+    val navController = NavHostController(LocalContext.current)
+
+    val member = Member(
+        name = "坂道 太郎",
+        imgUrl = "https://avatars.githubusercontent.com/u/52474650?v=4",
+    )
+    val uiState = SettingsUiState(
+        fave = member,
+    )
+
+    CustomSakaTheme {
+        FaveScreen(
+            navController,
+            uiState,
+        )
     }
 }

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveSettingConfirmScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveSettingConfirmScreen.kt
@@ -1,0 +1,112 @@
+package jp.mydns.kokoichi0206.settings.pages
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import jp.mydns.kokoichi0206.common.ui.theme.CustomSakaTheme
+import jp.mydns.kokoichi0206.feature.settings.R
+import jp.mydns.kokoichi0206.model.Member
+import jp.mydns.kokoichi0206.settings.SettingsUiState
+
+@Composable
+fun FaveSettingConfirmScreen(
+    uiState: SettingsUiState,
+    selected: Member,
+    onConfirmClicked: () -> Unit = {},
+    onCancelClicked: () -> Unit = {},
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        AsyncImage(
+            modifier = Modifier
+                .size(96.dp)
+                .border(
+                    width = 3.dp,
+                    color = Color.Gray.copy(alpha = 0.3f),
+                ),
+            model = selected.imgUrl,
+            contentDescription = "picture of ${selected.name}",
+            contentScale = ContentScale.Crop,
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text =  stringResource(R.string.my_fave_confirm_name, selected.name),
+            fontSize = 14.sp,
+            color = Color.Gray.copy(alpha = 0.9f)
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = stringResource(R.string.my_fave_confirm_confirm),
+            color = uiState.themeType.fontColor,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .clickable {
+                    onConfirmClicked()
+                }
+                .background(uiState.themeType.subColor)
+                .padding(horizontal = 64.dp, vertical = 12.dp)
+                .width(96.dp)
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = stringResource(R.string.my_fave_confirm_cancel),
+            color = Color.Gray.copy(alpha = 0.6f),
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .clickable {
+                    onCancelClicked()
+                }
+                .border(
+                    width = 1.dp,
+                    color = Color.Gray.copy(alpha = 0.6f)
+                )
+                .padding(horizontal = 64.dp, vertical = 12.dp)
+                .width(96.dp)
+        )
+    }
+}
+
+@Preview
+@Composable
+fun FaveSettingConfirmScreenPreview() {
+    val member = Member(
+        name = "坂道 太郎",
+        imgUrl = "https://avatars.githubusercontent.com/u/52474650?v=4",
+    )
+
+    CustomSakaTheme {
+        FaveSettingConfirmScreen(
+            uiState = SettingsUiState(),
+            member,
+        )
+    }
+}

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveSettingScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveSettingScreen.kt
@@ -1,0 +1,201 @@
+package jp.mydns.kokoichi0206.settings.pages
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import coil.compose.AsyncImage
+import jp.mydns.kokoichi0206.common.ui.theme.CustomSakaTheme
+import jp.mydns.kokoichi0206.feature.settings.R
+import jp.mydns.kokoichi0206.model.Member
+import jp.mydns.kokoichi0206.settings.SettingsUiState
+import jp.mydns.kokoichi0206.settings.components.SettingTopBar
+
+@Composable
+fun FaveSettingScreen(
+    navController: NavHostController,
+    uiState: SettingsUiState,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        // Top Bar
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+        ) {
+            SettingTopBar(
+                themeType = uiState.themeType,
+                text = stringResource(id = R.string.my_fave_set_member),
+                onArrowClick = {
+                    navController.popBackStack()
+                }
+            )
+        }
+
+        var selected by remember { mutableStateOf(uiState.fave) }
+
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .padding(12.dp)
+        ) {
+            items(uiState.allMembers) { member ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(4.dp)
+                        .clickable {
+                            selected = member
+                        }
+                        .border(
+                            width = 1.dp,
+                            color = if (selected == member) uiState.themeType.subColor else Color.Gray.copy(alpha = 0.3f),
+                        )
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    CircleCheckbox(
+                        selected = selected == member,
+                        selectedTint = uiState.themeType.subColor,
+                        onClick = {
+                            selected = member
+                        }
+                    )
+
+                    Spacer(modifier = Modifier.width(4.dp))
+
+                    AsyncImage(
+                        modifier = Modifier
+                            .size(48.dp)
+                            .border(
+                                width = 1.dp,
+                                color = Color.Gray.copy(alpha = 0.3f),
+                            ),
+                        model = member.imgUrl,
+                        contentDescription = "picture of ${member.name}",
+                        contentScale = ContentScale.Crop,
+                    )
+
+                    Spacer(modifier = Modifier.width(4.dp))
+
+                    Text(
+                        modifier = Modifier.padding(16.dp),
+                        text = member.name,
+                        fontSize = 14.sp,
+                    )
+                }
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(4.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                modifier = Modifier
+                    .background(uiState.themeType.subColor)
+                    .padding(horizontal = 64.dp, vertical = 4.dp),
+                text = stringResource(id = R.string.my_fave_confirm),
+                fontSize = 18.sp,
+                color = uiState.themeType.fontColor,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+fun CircleCheckbox(
+    selected: Boolean,
+    selectedTint: Color,
+    onClick: () -> Unit = {},
+) {
+    val imageVector = Icons.Filled.CheckCircle
+    val tint = if (selected) selectedTint else Color.White.copy(alpha = 0.8f)
+
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier.offset(x = 4.dp, y = 4.dp),
+        enabled = !selected,
+    ) {
+        Icon(
+            imageVector = imageVector, tint = tint,
+            modifier = Modifier
+                .background(Color.White, shape = CircleShape)
+                .border(
+                    width = 1.dp,
+                    color = Color.Gray.copy(0.3f),
+                    shape = CircleShape,
+                ),
+            contentDescription = "checkbox",
+        )
+    }
+}
+
+@Preview
+@Composable
+fun FaveSettingScreenPreview() {
+    val navController = NavHostController(LocalContext.current)
+
+    val member = Member(
+        name = "坂道 太郎",
+        imgUrl = "https://avatars.githubusercontent.com/u/52474650?v=4",
+    )
+    val all = listOf(
+        Member(
+            name = "坂道 太郎",
+            imgUrl = "https://avatars.githubusercontent.com/u/52474650?v=4",
+        ),
+        Member(
+            name = "坂道 二郎",
+            imgUrl = "https://avatars.githubusercontent.com/u/52474650?v=4",
+        ),
+    )
+    val uiState = SettingsUiState(
+        fave = member,
+        allMembers = all,
+    )
+
+    CustomSakaTheme {
+        FaveSettingScreen(
+            navController,
+            uiState,
+        )
+    }
+}

--- a/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveSettingScreen.kt
+++ b/feature/settings/src/main/java/jp/mydns/kokoichi0206/settings/pages/FaveSettingScreen.kt
@@ -48,6 +48,7 @@ import jp.mydns.kokoichi0206.settings.components.SettingTopBar
 fun FaveSettingScreen(
     navController: NavHostController,
     uiState: SettingsUiState,
+    onConfirmClicked: (Member) -> Unit = {},
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -129,6 +130,11 @@ fun FaveSettingScreen(
         ) {
             Text(
                 modifier = Modifier
+                    .clickable {
+                        selected?.let {
+                            onConfirmClicked(it)
+                        }
+                    }
                     .background(uiState.themeType.subColor)
                     .padding(horizontal = 64.dp, vertical = 4.dp),
                 text = stringResource(id = R.string.my_fave_confirm),

--- a/feature/settings/src/main/res/values-en/strings.xml
+++ b/feature/settings/src/main/res/values-en/strings.xml
@@ -20,6 +20,7 @@
     <string name="setting_about_app">About this app</string>
     <string name="my_fave">Favorite members</string>
     <string name="my_fave_set_member">Set favorite member</string>
+    <string name="my_fave_confirm">Confirm</string>
 
     <!--    Strings for QuizResultsScreen-->
     <string name="quiz_result_screen_title">Number of correct answers</string>

--- a/feature/settings/src/main/res/values-en/strings.xml
+++ b/feature/settings/src/main/res/values-en/strings.xml
@@ -19,6 +19,7 @@
     <string name="setting_share_app">Share this app</string>
     <string name="setting_about_app">About this app</string>
     <string name="my_fave">Favorite members</string>
+    <string name="my_fave_set_member">Set favorite member</string>
 
     <!--    Strings for QuizResultsScreen-->
     <string name="quiz_result_screen_title">Number of correct answers</string>

--- a/feature/settings/src/main/res/values-en/strings.xml
+++ b/feature/settings/src/main/res/values-en/strings.xml
@@ -21,6 +21,9 @@
     <string name="my_fave">Favorite members</string>
     <string name="my_fave_set_member">Set favorite member</string>
     <string name="my_fave_confirm">Confirm</string>
+    <string name="my_fave_confirm_name">Do you want to register %s as a favorite member?</string>
+    <string name="my_fave_confirm_confirm">Confirm</string>
+    <string name="my_fave_confirm_cancel">Cancel</string>
 
     <!--    Strings for QuizResultsScreen-->
     <string name="quiz_result_screen_title">Number of correct answers</string>

--- a/feature/settings/src/main/res/values-en/strings.xml
+++ b/feature/settings/src/main/res/values-en/strings.xml
@@ -18,6 +18,7 @@
     <string name="setting_set_theme_color">Theme colors</string>
     <string name="setting_share_app">Share this app</string>
     <string name="setting_about_app">About this app</string>
+    <string name="my_fave">Favorite members</string>
 
     <!--    Strings for QuizResultsScreen-->
     <string name="quiz_result_screen_title">Number of correct answers</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -21,6 +21,9 @@
     <string name="my_fave">推しメン機能</string>
     <string name="my_fave_set_member">推しメンを設定する</string>
     <string name="my_fave_confirm">登録確認</string>
+    <string name="my_fave_confirm_name">%sを推しメンに登録しますか？</string>
+    <string name="my_fave_confirm_confirm">決定する</string>
+    <string name="my_fave_confirm_cancel">もどる</string>
 
     <!--    Strings for QuizResultsScreen-->
     <string name="quiz_result_screen_title">クイズ正解数</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="setting_about_app">アプリについて</string>
     <string name="my_fave">推しメン機能</string>
     <string name="my_fave_set_member">推しメンを設定する</string>
+    <string name="my_fave_confirm">登録確認</string>
 
     <!--    Strings for QuizResultsScreen-->
     <string name="quiz_result_screen_title">クイズ正解数</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="setting_share_app">このアプリをシェアする</string>
     <string name="setting_about_app">アプリについて</string>
     <string name="my_fave">推しメン機能</string>
+    <string name="my_fave_set_member">推しメンを設定する</string>
 
     <!--    Strings for QuizResultsScreen-->
     <string name="quiz_result_screen_title">クイズ正解数</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="setting_set_theme_color">テーマカラー設定</string>
     <string name="setting_share_app">このアプリをシェアする</string>
     <string name="setting_about_app">アプリについて</string>
+    <string name="my_fave">推しメン機能</string>
 
     <!--    Strings for QuizResultsScreen-->
     <string name="quiz_result_screen_title">クイズ正解数</string>


### PR DESCRIPTION
## Issue 番号

Closed #102 

## 対応内容・対応背景
- 

## やったこと

- 推しメン選択機能
- データを端末に保存
- 写真をカスタマイズする機能
  - ローカルで uri のみ保存

## やってないこと
- 

## UI before / after


https://user-images.githubusercontent.com/52474650/235195569-ed674b9f-c884-4738-9d6d-b4dbc44d0186.mov



## テスト観点

## 補足
